### PR TITLE
Rename unused variable 'conn_state' to omit warning

### DIFF
--- a/lib/client.ml
+++ b/lib/client.ml
@@ -278,7 +278,7 @@ type request_info =
   }
 
 let rec return_response
-    ({ conn = Connection.Conn ({ impl = (module Http); fd; _ } as _conn_state)
+    { conn = Connection.Conn ({ impl = (module Http); fd; _ }
      ; conn_info
      ; config
      ; _

--- a/lib/client.ml
+++ b/lib/client.ml
@@ -278,7 +278,7 @@ type request_info =
   }
 
 let rec return_response
-    ({ conn = Connection.Conn ({ impl = (module Http); fd; _ } as conn_state)
+    ({ conn = Connection.Conn ({ impl = (module Http); fd; _ } as _conn_state)
      ; conn_info
      ; config
      ; _


### PR DESCRIPTION
Figured instead of disabling this warning in my dune-file perhaps you'd like a PR for it!