### PR TITLE
oneshot-client: Close file descriptors once the body has been read

### DIFF
--- a/lib/http_impl.ml
+++ b/lib/http_impl.ml
@@ -223,6 +223,7 @@ let create_h2c_connection (module Http2 : Http_intf.HTTP2) ~http_request fd =
     error
 
 let shutdown
-    : type a. (module Http_intf.HTTPCommon with type Client.t = a) -> a -> unit
+    : type a.
+      (module Http_intf.HTTPCommon with type Client.t = a) -> a -> unit Lwt.t
   =
  fun (module Http) conn -> Http.Client.shutdown conn

--- a/lib/http_intf.ml
+++ b/lib/http_intf.ml
@@ -65,7 +65,7 @@ module type Client = sig
     -> response_handler:response_handler
     -> write_body
 
-  val shutdown : t -> unit
+  val shutdown : t -> unit Lwt.t
 
   val is_closed : t -> bool
 end

--- a/lib/piaf.mli
+++ b/lib/piaf.mli
@@ -331,7 +331,7 @@ module Client : sig
     -> string
     -> (Response.t, string) Lwt_result.t
 
-  val shutdown : t -> unit
+  val shutdown : t -> unit Lwt.t
   (** [shutdown t] tears down the connection [t] and frees up all the resources
       associated with it. *)
 

--- a/nix/generic.nix
+++ b/nix/generic.nix
@@ -3,11 +3,13 @@
 with ocamlPackages;
 
 rec {
-  piaf = buildDune2Package {
+  piaf = buildDunePackage {
     pname = "piaf";
     version = "0.0.1-dev";
 
     src = lib.gitignoreSource ./..;
+
+    useDune2 = true;
 
     propagatedBuildInputs = [
       bigstringaf

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -2,8 +2,8 @@
 
 let
   overlays = builtins.fetchTarball {
-    url = https://github.com/anmonteiro/nix-overlays/archive/5d6ac00.tar.gz;
-    sha256 = "0dl92riggcz2zxrlrkqh51rbjz2kc5k8ad2wri1y2ivk3b6qa37n";
+    url = https://github.com/anmonteiro/nix-overlays/archive/8be291f.tar.gz;
+    sha256 = "10k44xzw9rafjmy1p1gj1kp9966nlyv2nhz9qqz57biw3qb4l1kh";
   };
 
 in


### PR DESCRIPTION
Depends on https://github.com/anmonteiro/ocaml-h2/pull/108 and https://github.com/anmonteiro/httpaf/pull/45