### PR TITLE
Improve documentation for `Client.create`

### DIFF
--- a/lib/piaf.mli
+++ b/lib/piaf.mli
@@ -281,7 +281,11 @@ module Client : sig
 
   val create : ?config:Config.t -> Uri.t -> (t, string) Lwt_result.t
   (** [create ?config uri] opens a connection to [uri] (initially) that can be
-      used to issue multiple requests to the remote endpoint. *)
+      used to issue multiple requests to the remote endpoint.
+
+      A client instance represents a connection to a single remote endpoint, and
+      the remaining functions in this module will issue requests to that
+      endpoint only. *)
 
   val head
     :  t


### PR DESCRIPTION
https://github.com/anmonteiro/piaf/issues/16 reports some confusion
around the API. Adding this note will hopefully clarify what the
intentions behind `Client.create` are for future users of the library.