### PR TITLE
Improvements to h2c upgrades

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,5 +18,4 @@ jobs:
         name: anmonteiro
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
     - name: "Run nix-build"
-      run: nix-build ./nix/ci/test.nix -A native  --argstr ocamlVersion ${{ matrix.ocamlVersion }}
-      # musl64
+      run: nix-build ./nix/ci/test.nix -A native -A musl64 --argstr ocamlVersion ${{ matrix.ocamlVersion }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: cachix/install-nix-action@v8
-    - uses: cachix/cachix-action@v5
+    - uses: cachix/cachix-action@v6
       with:
         name: anmonteiro
-        file: nix/ci/test.nix
-        attributes: native musl64
-        nixBuildArgs: --argstr ocamlVersion ${{ matrix.ocamlVersion }}
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+    - name: "Run nix-build"
+      run: nix-build ./nix/ci/test.nix -A native  --argstr ocamlVersion ${{ matrix.ocamlVersion }}
+      # musl64

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -119,3 +119,5 @@ let to_http2_config
   ; response_body_buffer_size = body_buffer_size
   ; enable_server_push = enable_http2_server_push
   }
+
+let to_http2_settings t = H2.Config.to_settings (to_http2_config t)

--- a/lib/headers.ml
+++ b/lib/headers.ml
@@ -32,9 +32,7 @@
 include H2.Headers
 
 (* TODO: Add user-agent if not defined *)
-let canonicalize_headers
-    ?(is_h2c_upgrade = false) ~body_length ~host ~version headers
-  =
+let canonicalize_headers ~body_length ~host ~version headers =
   let headers =
     match version with
     | { Versions.HTTP.major = 2; _ } ->
@@ -44,15 +42,6 @@ let canonicalize_headers
              (fun (name, value) -> String.lowercase_ascii name, value)
              headers)
     | { major = 1; _ } ->
-      let headers =
-        if is_h2c_upgrade then
-          ("Connection", "Upgrade, HTTP2-Settings")
-          :: ("Upgrade", "h2c")
-          :: ("HTTP2-Settings", "")
-          :: headers
-        else
-          headers
-      in
       add_unless_exists (of_list headers) "Host" host
     | _ ->
       failwith "unsupported version"

--- a/lib/http_impl.ml
+++ b/lib/http_impl.ml
@@ -200,6 +200,7 @@ let create_h2c_connection (module Http2 : Http_intf.HTTP2) ~http_request fd =
       (response_handler, response_error_handler)
       fd
   in
+  Log.info (fun m -> m "Connection state changed (HTTP/2 confirmed)");
   (* Doesn't write the body by design. The server holds on to the HTTP/1.1 body
    * that was sent as part of the upgrade. *)
   let open Lwt.Syntax in

--- a/lib/versions.ml
+++ b/lib/versions.ml
@@ -57,6 +57,8 @@ module HTTP = struct
   let v1_1 = { major = 1; minor = 1 }
 
   let v2_0 = { major = 2; minor = 0 }
+
+  let equal v1 v2 = compare v1 v2 = 0
 end
 
 module TLS = struct

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -2,8 +2,8 @@
 
 let
   overlays = builtins.fetchTarball {
-    url = https://github.com/anmonteiro/nix-overlays/archive/a4c8fcc9.tar.gz;
-    sha256 = "09mkdlcg1flnkhpksq6nv4c0dp92gnp7c7kzirx8czfyh594v7yw";
+    url = https://github.com/anmonteiro/nix-overlays/archive/1356ffa.tar.gz;
+    sha256 = "0g7sq60bi2hydgwcmkj7phsmn44awmxzvi3ihjvk04rcnd1ljdh7";
   };
 
 in

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -2,8 +2,8 @@
 
 let
   overlays = builtins.fetchTarball {
-    url = https://github.com/anmonteiro/nix-overlays/archive/1356ffa.tar.gz;
-    sha256 = "0g7sq60bi2hydgwcmkj7phsmn44awmxzvi3ihjvk04rcnd1ljdh7";
+    url = https://github.com/anmonteiro/nix-overlays/archive/a4c8fcc9.tar.gz;
+    sha256 = "09mkdlcg1flnkhpksq6nv4c0dp92gnp7c7kzirx8czfyh594v7yw";
   };
 
 in

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -2,8 +2,8 @@
 
 let
   overlays = builtins.fetchTarball {
-    url = https://github.com/anmonteiro/nix-overlays/archive/a4c8fcc9.tar.gz;
-    sha256 = "09mkdlcg1flnkhpksq6nv4c0dp92gnp7c7kzirx8czfyh594v7yw";
+    url = https://github.com/anmonteiro/nix-overlays/archive/94ea82d.tar.gz;
+    sha256 = "0kdxj56llf4s9ri12li81fgv5b2xy03afjsixymmzd8c6i8113d8";
   };
 
 in


### PR DESCRIPTION
- Send HTTP2-Settings as part of the h2c upgrade
- unrelated: close the connection properly for `HEAD` requests