### PR TITLE
Body: don't perform a copy when reading a body

### DIFF
--- a/lib/body.ml
+++ b/lib/body.ml
@@ -282,14 +282,8 @@ let of_prim_body
         Option.iter (fun f -> f (Lazy.force t)) on_eof;
         Body.close_reader body;
         Lwt.wakeup_later wakener None)
-      ~on_read:(fun fragment ~off ~len ->
-        (* TODO: delete this. This is fixed in the http/af version we use. *)
-        (* Note: we always need to make a copy here for now. See the following
-         * comment for an explanation why:
-         * https://github.com/inhabitedtype/httpaf/issues/140#issuecomment-517072327
-         *)
-        let fragment_copy = Bigstringaf.copy ~off ~len fragment in
-        let iovec = { IOVec.buffer = fragment_copy; off = 0; len } in
+      ~on_read:(fun buffer ~off ~len ->
+        let iovec = { IOVec.buffer; off; len } in
         Lwt.wakeup_later wakener (Some iovec));
     let t = Lazy.force t in
     Lwt.choose

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -121,6 +121,9 @@ let to_http2_config
   ; request_body_buffer_size = body_buffer_size
   ; response_body_buffer_size = body_buffer_size
   ; enable_server_push = enable_http2_server_push
+  ; (* Default to a flow control window of 1 MB.
+     * XXX(anmonteiro): This could probably be the default in h2? *)
+    initial_window_size = 1 lsl 20
   }
 
 let to_http2_settings t = H2.Config.to_settings (to_http2_config t)

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -121,9 +121,9 @@ let to_http2_config
   ; request_body_buffer_size = body_buffer_size
   ; response_body_buffer_size = body_buffer_size
   ; enable_server_push = enable_http2_server_push
-  ; (* Default to a flow control window of 1 MB.
-     * XXX(anmonteiro): This could probably be the default in h2? *)
-    initial_window_size = 1 lsl 20
+  ; (* Default to a flow control window of 128 MiB (should also be the default
+     * in H2). *)
+    initial_window_size = 1 lsl 27
   }
 
 let to_http2_settings t = H2.Config.to_settings (to_http2_config t)

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -3,7 +3,7 @@
 let
   overlays =
     builtins.fetchTarball
-      https://github.com/anmonteiro/nix-overlays/archive/8937afc.tar.gz;
+      https://github.com/anmonteiro/nix-overlays/archive/8cefb11.tar.gz;
 
 in
 


### PR DESCRIPTION
we're now using implementations handle either:

- flow-control (h2), and can effectively tell the peer to stop
  sending us DATA frames if we haven't scheduled reads (consumed the
  body stream in Piaf's case).
- backpressure (http/af), which issues Yield operations to the
  underlying runtime if we're not reading from the body.