### PR TITLE
Add `default_headers` to the client configuration

### DIFF
--- a/lib/config.ml
+++ b/lib/config.ml
@@ -69,9 +69,11 @@ type t =
   ; body_buffer_size : int
         (** Buffer size used for request and response bodies. *)
   ; enable_http2_server_push : bool
+        (* ; max_concurrent_streams : int ; initial_window_size : int *)
         (** TODO(anmonteiro): these are HTTP/2 specific and we're probably OK
             with the defaults *)
-        (* ; max_concurrent_streams : int ; initial_window_size : int *)
+  ; default_headers : (Headers.name * Headers.value) list
+        (** Set default headers (on the client) to be sent on every request. *)
   }
 
 let default =
@@ -91,6 +93,7 @@ let default =
   ; body_buffer_size = 0x1000
   ; (* TODO: we don't really support push yet. *)
     enable_http2_server_push = false
+  ; default_headers = []
   }
 
 let to_http1_config { body_buffer_size; buffer_size; _ } =

--- a/lib/headers.ml
+++ b/lib/headers.ml
@@ -40,6 +40,8 @@ module Well_known = struct
     let host = ":authority"
   end
 
+  let authorization = "authorization"
+
   let connection = "connection"
 
   let content_length = "content-length"

--- a/lib/piaf.mli
+++ b/lib/piaf.mli
@@ -188,6 +188,8 @@ module Headers : sig
       val host : string
     end
 
+    val authorization : string
+
     val connection : string
 
     val content_length : string
@@ -293,6 +295,8 @@ module Config : sig
     ; body_buffer_size : int
           (** Buffer size used for request and response bodies. *)
     ; enable_http2_server_push : bool
+    ; default_headers : (Headers.name * Headers.value) list
+          (** Set default headers (on the client) to be sent on every request. *)
     }
 
   val default : t

--- a/lib_test/helper_server.ml
+++ b/lib_test/helper_server.ml
@@ -21,6 +21,8 @@ let request_handler { Server.request; _ } =
                ; Well_known.connection, "close"
                ]))
       `Moved_permanently
+  | [ "echo_headers" ] ->
+    Lwt.wrap1 (Response.create ~headers:request.headers) `OK
   | _ ->
     assert false
 

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -3,7 +3,7 @@
 let
   overlays =
     builtins.fetchTarball
-      https://github.com/anmonteiro/nix-overlays/archive/5eab7d8.tar.gz;
+      https://github.com/anmonteiro/nix-overlays/archive/9b9a5cc.tar.gz;
 
 in
 


### PR DESCRIPTION
The headers in this field will be sent with every request. Useful to
configure a client that always sends e.g. authorization headers.