### PR TITLE
piaf.server: prefer Lwt.dont_wait to the global exception hook

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,8 @@ Unreleased
   ([#112](https://github.com/anmonteiro/piaf/pull/112))
 - Piaf.Response: add `or_internal_error`
   ([#120](https://github.com/anmonteiro/piaf/pull/120))
+- Piaf.Server: prefer `Lwt.dont_wait` to the global exception hook
+  ([#123](https://github.com/anmonteiro/piaf/pull/123))
 
 0.1.0 2021-02-03
 --------------

--- a/flake.lock
+++ b/flake.lock
@@ -35,11 +35,11 @@
         "flake-utils": "flake-utils_2"
       },
       "locked": {
-        "lastModified": 1646447780,
-        "narHash": "sha256-y9diaTU+y5WnovGTlhO3v5VrvN87Oa79KE3c/hVIxaA=",
+        "lastModified": 1646974360,
+        "narHash": "sha256-m9WAtsLLMT2dpFmjB8j7/HYtAygTonF6ciqflTub5Xc=",
         "owner": "anmonteiro",
         "repo": "nix-overlays",
-        "rev": "8bc4e7e5f4d7579d5875ec1c11f5f20bb632b1fc",
+        "rev": "f7de94347b210e406bbe42b39bf56041483fe20d",
         "type": "github"
       },
       "original": {

--- a/lib/server.ml
+++ b/lib/server.ml
@@ -133,9 +133,6 @@ let request_handler handler client_addr reqd =
       (Reqd.request_body reqd)
   in
   let request = Request.of_http1 ~body:request_body request in
-  (* Set the async exception hook for threads that raise exceptions within the
-   * one we start below. *)
-  (* Lwt.async_exception_hook := report_exn reqd; *)
   Lwt.dont_wait
     (fun () ->
       let+ ({ Response.headers; body; _ } as response) =


### PR DESCRIPTION
The async exception hook is not meant to be used by libraries.