### PR TITLE
fix build with websocketaf dependency missing

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -29,7 +29,15 @@ with pkgs;
       git
       opam
     ] else [ ]) ++
-    (with ocamlPackages; [ ocaml-lsp merlin ocamlformat utop ]);
+    (with ocamlPackages; [ 
+    # packages needed for development
+    ocaml-lsp 
+    merlin 
+    ocamlformat
+    utop 
+    # packages needed for the examples 
+    websocketaf 
+  ]);
 }).overrideAttrs (o: {
   propagatedBuildInputs = filterDrvs o.propagatedBuildInputs;
   buildInputs = filterDrvs o.buildInputs;


### PR DESCRIPTION
I don't know if this is correct because it's a dependency only used for an example project.