### PR TITLE
add ocaml-lsp as a dev dependency

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -29,7 +29,7 @@ with pkgs;
       git
       opam
     ] else [ ]) ++
-    (with ocamlPackages; [ merlin ocamlformat utop ]);
+    (with ocamlPackages; [ ocaml-lsp merlin ocamlformat utop ]);
 }).overrideAttrs (o: {
   propagatedBuildInputs = filterDrvs o.propagatedBuildInputs;
   buildInputs = filterDrvs o.buildInputs;


### PR DESCRIPTION
It's useful for new developers that don't use merlin directly.