### PR TITLE
Websocket support and API

### DIFF
--- a/bin/carl.ml
+++ b/bin/carl.ml
@@ -78,7 +78,7 @@ type cli =
   ; head : bool
   ; headers : (string * string) list
   ; include_ : bool
-  ; max_http_version : Versions.ALPN.t
+  ; max_http_version : Versions.HTTP.t
   ; h2c_upgrade : bool
   ; http2_prior_knowledge : bool
   ; cacert : Cert.t option
@@ -109,7 +109,7 @@ let pp_response_headers formatter { Response.headers; status; version; _ } =
   Format.fprintf
     formatter
     "@[%a %a%s@]@\n@[%a@]"
-    Versions.HTTP.pp_hum
+    Versions.HTTP.pp
     version
     Status.pp_hum
     status
@@ -746,7 +746,7 @@ module CLI = struct
         (match use_http_2, use_http_1_1, use_http_1_0 with
         | true, _, _ | false, false, false ->
           (* Default to the highest supported if no override specified. *)
-          Versions.ALPN.HTTP_2
+          Versions.HTTP.HTTP_2
         | false, true, _ -> HTTP_1_1
         | false, false, true -> HTTP_1_0)
     ; h2c_upgrade = use_http_2

--- a/examples/eio/dune
+++ b/examples/eio/dune
@@ -1,3 +1,7 @@
 (executables
- (names eio_get eio_echo_post)
+ (names
+  eio_get
+  eio_echo_post
+  echo_server_upgrade
+  eio_wscat)
  (libraries piaf logs logs.fmt fmt.tty eio_main))

--- a/examples/eio/dune
+++ b/examples/eio/dune
@@ -1,7 +1,3 @@
 (executables
- (names
-  eio_get
-  eio_echo_post
-  echo_server_upgrade
-  eio_wscat)
+ (names eio_get eio_echo_post echo_server_upgrade eio_wscat)
  (libraries piaf logs logs.fmt fmt.tty eio_main))

--- a/examples/eio/echo_server_upgrade.ml
+++ b/examples/eio/echo_server_upgrade.ml
@@ -7,6 +7,7 @@ let connection_handler { Server.request; _ } =
       Stream.iter
         ~f:(fun (_opcode, frame) -> Ws.Descriptor.send_string wsd frame)
         frames)
+  |> Result.get_ok
 
 let setup_log ?style_renderer level =
   Fmt_tty.setup_std_outputs ?style_renderer ();
@@ -15,7 +16,7 @@ let setup_log ?style_renderer level =
   ()
 
 let () =
-  setup_log Logs.Info;
+  setup_log Logs.Debug;
   let port = ref 8080 in
   Arg.parse
     [ "-p", Arg.Set_int port, " Listening port number (8080 by default)" ]

--- a/examples/eio/echo_server_upgrade.ml
+++ b/examples/eio/echo_server_upgrade.ml
@@ -1,0 +1,87 @@
+open Eio.Std
+open Piaf
+
+let sha1 s = s |> Digestif.SHA1.digest_string |> Digestif.SHA1.to_raw_string
+
+let connection_handler =
+  let websocket_handler _client_address wsd =
+    let frame ~opcode ~is_fin:_ ~len:_ payload =
+      match opcode with
+      | #Websocketaf.Websocket.Opcode.standard_non_control as opcode ->
+        let rec on_read bs ~off ~len =
+          Websocketaf.Wsd.schedule wsd bs ~kind:opcode ~off ~len;
+          Websocketaf.Payload.schedule_read payload ~on_eof ~on_read
+        and on_eof () = () in
+        Websocketaf.Payload.schedule_read payload ~on_eof ~on_read
+      | `Connection_close -> Websocketaf.Wsd.close wsd
+      | `Ping -> Websocketaf.Wsd.send_pong wsd
+      | `Pong | `Other _ -> ()
+    in
+    let eof () =
+      Format.eprintf "EOF\n%!";
+      Websocketaf.Wsd.close wsd
+    in
+    { Websocketaf.Server_connection.frame; eof }
+  in
+  let error_handler wsd (`Exn exn) =
+    let message = Printexc.to_string exn in
+    let payload = Bytes.of_string message in
+    Websocketaf.Wsd.send_bytes
+      wsd
+      ~kind:`Text
+      payload
+      ~off:0
+      ~len:(Bytes.length payload);
+    Websocketaf.Wsd.close wsd
+  in
+  let upgrade_handler addr upgrade =
+    let ws_conn =
+      Websocketaf.Server_connection.create_websocket
+        ~error_handler
+        (websocket_handler addr)
+    in
+    upgrade (Gluten.make (module Websocketaf.Server_connection) ws_conn)
+  in
+  fun { Server.request; ctx } ->
+    let httpaf_headers =
+      Httpaf.Headers.of_rev_list (Headers.to_rev_list request.headers)
+    in
+    let response =
+      match
+        Websocketaf.Handshake.upgrade_headers
+          ~sha1
+          ~request_method:request.meth
+          httpaf_headers
+      with
+      | Ok upgrade_headers ->
+        Response.upgrade
+          ~headers:(Headers.of_list upgrade_headers)
+          (upgrade_handler ctx)
+      | Error err_str ->
+        Response.of_string
+          ~body:err_str
+          ~headers:(Headers.of_list [ "Connection", "close" ])
+          `Bad_request
+    in
+    response
+
+let setup_log ?style_renderer level =
+  Fmt_tty.setup_std_outputs ?style_renderer ();
+  Logs.set_level (Some level);
+  Logs.set_reporter (Logs_fmt.reporter ());
+  ()
+
+let () =
+  let port = ref 8080 in
+  Arg.parse
+    [ "-p", Arg.Set_int port, " Listening port number (8080 by default)" ]
+    ignore
+    "Echoes websocket messages. Runs forever.";
+  Eio_main.run (fun env ->
+      Switch.run (fun sw ->
+          let config = Server.Config.create !port in
+          let server = Server.create ~config connection_handler in
+          let _command = Server.Command.start ~sw env server in
+          ()
+          (* Eio.Time.sleep (Eio.Stdenv.clock env) 5.; *)
+          (* Server.Command.shutdown command *)))

--- a/examples/eio/echo_server_upgrade.ml
+++ b/examples/eio/echo_server_upgrade.ml
@@ -1,69 +1,21 @@
 open Eio.Std
 open Piaf
 
-let sha1 s = s |> Digestif.SHA1.digest_string |> Digestif.SHA1.to_raw_string
-
 let connection_handler =
-  let websocket_handler _client_address wsd =
-    let frame ~opcode ~is_fin:_ ~len:_ payload =
-      match opcode with
-      | #Websocketaf.Websocket.Opcode.standard_non_control as opcode ->
-        let rec on_read bs ~off ~len =
-          Websocketaf.Wsd.schedule wsd bs ~kind:opcode ~off ~len;
-          Websocketaf.Payload.schedule_read payload ~on_eof ~on_read
-        and on_eof () = () in
-        Websocketaf.Payload.schedule_read payload ~on_eof ~on_read
-      | `Connection_close -> Websocketaf.Wsd.close wsd
-      | `Ping -> Websocketaf.Wsd.send_pong wsd
-      | `Pong | `Other _ -> ()
-    in
-    let eof () =
-      Format.eprintf "EOF\n%!";
-      Websocketaf.Wsd.close wsd
-    in
-    { Websocketaf.Server_connection.frame; eof }
+  let websocket_handler wsd =
+    let frames = Ws.Descriptor.frames wsd in
+    Stream.iter
+      ~f:(fun (opcode, frame) ->
+        match opcode with
+        | #Websocketaf.Websocket.Opcode.standard_non_control ->
+          Ws.Descriptor.send_string wsd frame
+        | `Connection_close -> Ws.Descriptor.close wsd
+        | `Ping -> Ws.Descriptor.send_pong wsd
+        | `Pong | `Other _ -> ())
+      frames
   in
-  let error_handler wsd (`Exn exn) =
-    let message = Printexc.to_string exn in
-    let payload = Bytes.of_string message in
-    Websocketaf.Wsd.send_bytes
-      wsd
-      ~kind:`Text
-      payload
-      ~off:0
-      ~len:(Bytes.length payload);
-    Websocketaf.Wsd.close wsd
-  in
-  let upgrade_handler addr upgrade =
-    let ws_conn =
-      Websocketaf.Server_connection.create_websocket
-        ~error_handler
-        (websocket_handler addr)
-    in
-    upgrade (Gluten.make (module Websocketaf.Server_connection) ws_conn)
-  in
-  fun { Server.request; ctx } ->
-    let httpaf_headers =
-      Httpaf.Headers.of_rev_list (Headers.to_rev_list request.headers)
-    in
-    let response =
-      match
-        Websocketaf.Handshake.upgrade_headers
-          ~sha1
-          ~request_method:request.meth
-          httpaf_headers
-      with
-      | Ok upgrade_headers ->
-        Response.upgrade
-          ~headers:(Headers.of_list upgrade_headers)
-          (upgrade_handler ctx)
-      | Error err_str ->
-        Response.of_string
-          ~body:err_str
-          ~headers:(Headers.of_list [ "Connection", "close" ])
-          `Bad_request
-    in
-    response
+  fun { Server.request; _ } ->
+    Response.Upgrade.websocket ~f:websocket_handler request
 
 let setup_log ?style_renderer level =
   Fmt_tty.setup_std_outputs ?style_renderer ();
@@ -72,6 +24,7 @@ let setup_log ?style_renderer level =
   ()
 
 let () =
+  setup_log Logs.Info;
   let port = ref 8080 in
   Arg.parse
     [ "-p", Arg.Set_int port, " Listening port number (8080 by default)" ]

--- a/examples/eio/eio_echo_post.ml
+++ b/examples/eio/eio_echo_post.ml
@@ -52,7 +52,7 @@ let setup_log ?style_renderer level =
   ()
 
 let () =
-  setup_log Logs.Debug;
+  setup_log Logs.Info;
   let port = ref 8080 in
   Arg.parse
     [ "-p", Arg.Set_int port, " Listening port number (8080 by default)" ]

--- a/examples/eio/eio_wscat.ml
+++ b/examples/eio/eio_wscat.ml
@@ -1,0 +1,79 @@
+open Eio.Std
+
+module Result = struct
+  include Result
+
+  let ( let+ ) result f = map f result
+  let ( let* ) = bind
+
+  let ( and* ) r1 r2 =
+    match r1, r2 with
+    | Ok x, Ok y -> Ok (x, y)
+    | Ok _, Error e | Error e, Ok _ | Error e, Error _ -> Error e
+end
+
+let stdin_loop ~stdin wsd =
+  let rec input_loop buf wsd =
+    let open Piaf in
+    let line = Eio.Buf_read.line buf in
+    traceln "< %s" line;
+    match line with
+    | "exit" -> Ws.Descriptor.close wsd
+    | _ ->
+      Ws.Descriptor.send_string wsd line;
+      input_loop buf wsd
+  in
+  let buf = Eio.Buf_read.of_flow stdin ~initial_size:100 ~max_size:1_000_000 in
+  input_loop buf wsd
+
+let rec consume_frames frames =
+  match Stream.take frames with
+  | Some (_code, frame) ->
+    Format.eprintf ">> %s@." frame;
+    consume_frames frames
+  | None -> ()
+
+let request ~env ~sw host =
+  let open Piaf in
+  let open Result in
+  let stdin = Eio.Stdenv.stdin env in
+  let* client =
+    Client.create
+      env
+      ~sw
+      ~config:
+        { Config.default with
+          follow_redirects = true
+        ; allow_insecure = true
+        ; flush_headers_immediately = true
+        }
+      (Uri.of_string host)
+  in
+  let+ wsd = Client.ws_upgrade client "/" in
+  let frames = Ws.Descriptor.frames wsd in
+  Fiber.both (fun () -> consume_frames frames) (fun () -> stdin_loop ~stdin wsd);
+  Client.shutdown client
+
+let setup_log ?style_renderer level =
+  Fmt_tty.setup_std_outputs ?style_renderer ();
+  Logs.set_level level;
+  Logs.set_reporter (Logs_fmt.reporter ());
+  ()
+
+let () =
+  setup_log (Some Logs.Info);
+  let host = ref None in
+  Arg.parse
+    []
+    (fun host_argument -> host := Some host_argument)
+    "eio_get.exe HOST";
+  let host =
+    match !host with
+    | None -> failwith "No hostname provided"
+    | Some host -> host
+  in
+  Eio_main.run (fun env ->
+      Eio.Switch.run (fun sw ->
+          match request ~sw ~env host with
+          | Ok () -> ()
+          | Error e -> failwith (Piaf.Error.to_string e)))

--- a/examples/eio/eio_wscat.ml
+++ b/examples/eio/eio_wscat.ml
@@ -30,12 +30,12 @@ let request ~env ~sw host =
     (fun () ->
       let stdin = Eio.Stdenv.stdin env in
       let buf = Eio.Buf_read.of_flow stdin ~initial_size:100 ~max_size:1_000 in
-      stdin_loop ~stdin buf wsd)
+      stdin_loop ~stdin buf wsd;
+      Client.shutdown client)
     (fun () ->
       Stream.iter
         ~f:(fun (_opcode, frame) -> Format.printf ">> %s@." frame)
-        (Ws.Descriptor.frames wsd));
-  Client.shutdown client
+        (Ws.Descriptor.frames wsd))
 
 let setup_log ?style_renderer level =
   Fmt_tty.setup_std_outputs ?style_renderer ();
@@ -44,7 +44,7 @@ let setup_log ?style_renderer level =
   ()
 
 let () =
-  setup_log (Some Logs.Info);
+  setup_log (Some Logs.Debug);
   let host = ref None in
   Arg.parse
     []

--- a/flake.lock
+++ b/flake.lock
@@ -38,11 +38,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1664390629,
-        "narHash": "sha256-XwYL9wtdpKo+F/rqLolfA3wlrQubYcy4lhZ2KOebg30=",
+        "lastModified": 1664481175,
+        "narHash": "sha256-7T3VS0oyvk0Zgm0hCGvYXTt1dC5dTEHv0wkTEXbOmgk=",
         "owner": "nix-ocaml",
         "repo": "nix-overlays",
-        "rev": "974511a254b3c56233e23e069532fbefd7f62166",
+        "rev": "b5938fd051da676eb64c37990f8cb07d639e0723",
         "type": "github"
       },
       "original": {
@@ -53,17 +53,17 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1664324903,
-        "narHash": "sha256-CTMKU5JCA3M4VaAVXGVQpchvGc8Yj2Ym2wXOlJPcZyk=",
+        "lastModified": 1664368096,
+        "narHash": "sha256-oUaX3geCYZFYO+4Ktf6D8WDNtYZNTQllqM5h045/KTQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0c3649a83a3f484aa8328157b0facb36435135e1",
+        "rev": "f56d319e680852bea73504b3e001eefb1e837c50",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0c3649a83a3f484aa8328157b0facb36435135e1",
+        "rev": "f56d319e680852bea73504b3e001eefb1e837c50",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -38,11 +38,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1664345928,
-        "narHash": "sha256-bDhzw7pkOfih4JQqFYFu6NF42exa5/NhexCOGXus5zU=",
+        "lastModified": 1664390629,
+        "narHash": "sha256-XwYL9wtdpKo+F/rqLolfA3wlrQubYcy4lhZ2KOebg30=",
         "owner": "nix-ocaml",
         "repo": "nix-overlays",
-        "rev": "b2ce484edab24b226dc72cbe5af0dec7aeb26b2a",
+        "rev": "974511a254b3c56233e23e069532fbefd7f62166",
         "type": "github"
       },
       "original": {
@@ -53,17 +53,17 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1664281702,
-        "narHash": "sha256-haixZ4TJLu1Dciow54wrHrHvlGDVr5sW6MTeAV/ZLuI=",
+        "lastModified": 1664324903,
+        "narHash": "sha256-CTMKU5JCA3M4VaAVXGVQpchvGc8Yj2Ym2wXOlJPcZyk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7e52b35fe98481a279d89f9c145f8076d049d2b9",
+        "rev": "0c3649a83a3f484aa8328157b0facb36435135e1",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7e52b35fe98481a279d89f9c145f8076d049d2b9",
+        "rev": "0c3649a83a3f484aa8328157b0facb36435135e1",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -38,11 +38,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1664481175,
-        "narHash": "sha256-7T3VS0oyvk0Zgm0hCGvYXTt1dC5dTEHv0wkTEXbOmgk=",
+        "lastModified": 1665956990,
+        "narHash": "sha256-7+/A/y7c+XVNYfE8O1OLVO6CoqVYniocKwshUKcYawI=",
         "owner": "nix-ocaml",
         "repo": "nix-overlays",
-        "rev": "b5938fd051da676eb64c37990f8cb07d639e0723",
+        "rev": "c855909e2182416ffad49dae2231b0ff1688e914",
         "type": "github"
       },
       "original": {
@@ -53,17 +53,17 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1664368096,
-        "narHash": "sha256-oUaX3geCYZFYO+4Ktf6D8WDNtYZNTQllqM5h045/KTQ=",
+        "lastModified": 1665922128,
+        "narHash": "sha256-D2+U5xF4AiSMPTBZ6V+wudrxmxM+Fnw8pW7PUWC1yPo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f56d319e680852bea73504b3e001eefb1e837c50",
+        "rev": "d7c3a973c7f20cfeca999d03e3da7344e0bb55f1",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f56d319e680852bea73504b3e001eefb1e837c50",
+        "rev": "d7c3a973c7f20cfeca999d03e3da7344e0bb55f1",
         "type": "github"
       }
     },

--- a/lib/body.ml
+++ b/lib/body.ml
@@ -77,40 +77,45 @@ type length =
   | `Close_delimited
   ]
 
+type body_stream =
+  { stream : Bigstringaf.t IOVec.t Stream.t
+  ; mutable read_counter : int
+  ; mutable error_received : Error.t Promise.t
+  }
+
+type sendfile_descr =
+  { fd : Unix.file_descr
+  ; waiter : unit Promise.t
+  ; notifier : unit Promise.u
+  ; mutable error_received : Error.t Promise.t
+  }
+
 type contents =
   [ `Empty of Optional_handler.t
   | `String of string
   | `Bigstring of Bigstringaf.t IOVec.t
-  | `Stream of Bigstringaf.t IOVec.t Stream.t
-  | `Sendfile of
-    Unix.file_descr
-    * (* Waiter and notifier for when the fd closes. *)
-    unit Promise.t
-    * unit Promise.u
+  | `Stream of body_stream
+  | `Sendfile of sendfile_descr
   ]
 
 type t =
   { length : length
   ; contents : contents
-  ; mutable error_received : Error.t Promise.t
-  ; mutable read_counter : int
   }
 
 (* Never resolves, giving a chance for the normal successful flow to always
  * resolve. *)
 let default_error_received, _ = Promise.create ()
-
-let create ~length contents =
-  { length
-  ; contents
-  ; error_received = default_error_received
-  ; read_counter = 0
-  }
-
+let create ~length contents = { length; contents }
 let length { length; _ } = length
 let contents { contents; _ } = contents
 let empty = create ~length:(`Fixed 0L) (`Empty Optional_handler.none)
-let of_stream ?(length = `Chunked) stream = create ~length (`Stream stream)
+
+let of_stream ?(length = `Chunked) stream =
+  create
+    ~length
+    (`Stream
+      { stream; read_counter = 0; error_received = default_error_received })
 
 let of_string_stream ?(length = `Chunked) stream =
   let stream =
@@ -120,7 +125,10 @@ let of_string_stream ?(length = `Chunked) stream =
         IOVec.make (Bigstringaf.of_string ~off:0 ~len s) ~off:0 ~len)
       stream
   in
-  create ~length (`Stream stream)
+  create
+    ~length
+    (`Stream
+      { stream; read_counter = 0; error_received = default_error_received })
 
 let of_string s =
   let length = `Fixed (Int64.of_int (String.length s)) in
@@ -148,8 +156,12 @@ let sendfile ?length path =
       `Fixed (Int64.of_int st_size)
     | Some length -> length
   in
-  let t, u = Promise.create () in
-  Ok (create ~length (`Sendfile (fd, t, u)))
+  let waiter, notifier = Promise.create () in
+  Ok
+    (create
+       ~length
+       (`Sendfile
+         { fd; waiter; notifier; error_received = default_error_received }))
 
 (* TODO: accept buffer for I/O, so that caller can pool buffers? *)
 let stream_of_fd ?on_close fd =
@@ -180,10 +192,11 @@ let to_stream { contents; _ } =
     Stream.of_list
       [ IOVec.make (Bigstringaf.of_string ~off:0 ~len s) ~off:0 ~len ]
   | `Bigstring iovec -> Stream.of_list [ iovec ]
-  | `Stream stream -> stream
-  | `Sendfile (fd, _, u) -> stream_of_fd ~on_close:(Promise.resolve u) fd
+  | `Stream { stream; _ } -> stream
+  | `Sendfile { fd; notifier; _ } ->
+    stream_of_fd ~on_close:(Promise.resolve notifier) fd
 
-let stream_to_string { length; _ } stream =
+let stream_to_string ~length stream =
   let len =
     match length with
     | `Fixed n -> Int64.to_int n
@@ -201,11 +214,14 @@ let stream_to_string { length; _ } stream =
     stream;
   Buffer.contents result_buffer
 
-let or_error t ~stream v =
+let error_p : contents -> Error.t Promise.t = function
+  | `Sendfile { error_received; _ } | `Stream { error_received; _ } ->
+    error_received
+  | _ -> default_error_received
+
+let or_error ~error_p ~stream v =
   Promise.await (Stream.closed stream);
-  match Promise.peek t.error_received with
-  | Some error -> Error error
-  | None -> Ok v
+  match Promise.peek error_p with Some error -> Error error | None -> Ok v
 
 let to_string ({ contents; _ } as t) =
   match contents with
@@ -213,13 +229,13 @@ let to_string ({ contents; _ } as t) =
   | `String s -> Ok s
   | `Bigstring { IOVec.buffer; off; len } ->
     Ok (Bigstringaf.substring ~off ~len buffer)
-  | `Stream stream ->
-    let str = stream_to_string t stream in
-    or_error t ~stream str
-  | `Sendfile (fd, _, u) ->
-    let stream = stream_of_fd ~on_close:(Promise.resolve u) fd in
-    let str = stream_to_string t stream in
-    or_error t ~stream str
+  | `Stream { stream; error_received; _ } ->
+    let str = stream_to_string ~length:t.length stream in
+    or_error ~error_p:error_received ~stream str
+  | `Sendfile { fd; error_received; notifier; _ } ->
+    let stream = stream_of_fd ~on_close:(Promise.resolve notifier) fd in
+    let str = stream_to_string ~length:t.length stream in
+    or_error ~error_p:error_received ~stream str
 
 let to_string_stream { contents; _ } =
   match contents with
@@ -227,55 +243,64 @@ let to_string_stream { contents; _ } =
   | `String s -> Stream.of_list [ s ]
   | `Bigstring { IOVec.buffer; off; len } ->
     Stream.of_list [ Bigstringaf.substring ~off ~len buffer ]
-  | `Stream stream ->
+  | `Stream { stream; _ } ->
     Stream.map
       ~f:(fun { IOVec.buffer; off; len } ->
         Bigstringaf.substring buffer ~off ~len)
       stream
-  | `Sendfile (fd, _, u) ->
-    let stream = stream_of_fd ~on_close:(Promise.resolve u) fd in
+  | `Sendfile { fd; notifier; _ } ->
+    let stream = stream_of_fd ~on_close:(Promise.resolve notifier) fd in
     Stream.map
       ~f:(fun { IOVec.buffer; off; len } ->
         Bigstringaf.substring buffer ~off ~len)
       stream
 
-let drain ({ contents; _ } as t) =
+let drain { contents; _ } =
   match contents with
   | `Empty _ | `String _ | `Bigstring _ -> Ok ()
-  | `Stream stream ->
+  | `Stream { stream; error_received; _ } ->
     Stream.drain stream;
-    or_error t ~stream ()
-  | `Sendfile (fd, _, _) ->
+    or_error ~error_p:error_received ~stream ()
+  | `Sendfile { fd; _ } ->
     Unix_fd.ensure_closed fd;
     Ok ()
 
 let drain_available { contents; _ } =
   match contents with
   | `Empty _ | `String _ | `Bigstring _ -> ()
-  | `Stream stream -> Stream.drain_available stream
-  | `Sendfile (fd, _, _) -> Unix_fd.ensure_closed fd
+  | `Stream { stream; _ } -> Stream.drain_available stream
+  | `Sendfile { fd; _ } -> Unix_fd.ensure_closed fd
 
 let is_closed t =
   match t.contents with
   | `Empty _ | `String _ | `Bigstring _ -> true
-  | `Stream stream -> Stream.is_closed stream
-  | `Sendfile (fd, _, _) -> not (Unix_fd.is_valid fd)
+  | `Stream { stream; _ } -> Stream.is_closed stream
+  | `Sendfile { fd; _ } -> not (Unix_fd.is_valid fd)
 
-let is_errored t = Promise.is_resolved t.error_received
+let is_errored t =
+  match t.contents with
+  | `Sendfile { error_received; _ } | `Stream { error_received; _ } ->
+    Promise.is_resolved error_received
+  | _ -> false
 
 let closed t =
   match t.contents with
   | `Empty _ | `String _ | `Bigstring _ -> Ok ()
-  | `Stream stream -> or_error t ~stream ()
-  | `Sendfile (_fd, p, _u) ->
-    Promise.await p;
-    Ok ()
+  | `Stream { stream; error_received; _ } ->
+    or_error ~error_p:error_received ~stream ()
+  | `Sendfile { waiter; _ } -> Ok (Promise.await waiter)
 
 let when_closed ~f t = f (closed t)
 
+let embed_error_received t error_received =
+  match t.contents with
+  | `Stream s -> s.error_received <- error_received
+  | `Sendfile s -> s.error_received <- error_received
+  | _ -> ()
+
 (* "Primitive" body types for http/af / h2 compatibility *)
-module type BODY = sig
-  module Reader : sig
+module Raw = struct
+  module type Reader = sig
     type t
 
     val close : t -> unit
@@ -289,7 +314,7 @@ module type BODY = sig
     val is_closed : t -> bool
   end
 
-  module Writer : sig
+  module type Writer = sig
     type t
 
     val write_char : t -> char -> unit
@@ -300,131 +325,142 @@ module type BODY = sig
     val close : t -> unit
     val is_closed : t -> bool
   end
+
+  module type BODY = sig
+    module Reader : Reader
+    module Writer : Writer
+  end
+
+  let to_stream
+      : type a.
+        (module Reader with type t = a)
+        -> ?on_eof:(body_stream -> unit)
+        -> body_length:length
+        -> a
+        -> body_stream
+    =
+   fun (module Reader) ?on_eof ~body_length body ->
+    let read_fn t () =
+      let t = Lazy.force t in
+      let p, u = Promise.create () in
+      let on_read_direct buffer ~off ~len =
+        Promise.resolve u (Some (IOVec.make buffer ~off ~len))
+      and on_read_with_yield buffer ~off ~len =
+        Fiber.yield ();
+        Promise.resolve u (Some (IOVec.make buffer ~off ~len))
+      in
+      t.read_counter <- t.read_counter + 1;
+      let on_read =
+        if t.read_counter > 128
+        then (
+          t.read_counter <- 0;
+          on_read_with_yield)
+        else on_read_direct
+      in
+      Reader.schedule_read
+        body
+        ~on_eof:(fun () ->
+          Option.iter (fun f -> f t) on_eof;
+          Reader.close body;
+          Promise.resolve u None)
+        ~on_read;
+      Fiber.first
+        (fun () -> Promise.await p)
+        (fun () ->
+          match Promise.await t.error_received with
+          | (_ : Error.t) ->
+            (* `None` closes the stream. The promise `t.error_received` remains
+             * fulfilled, which signals that the stream hasn't closed cleanly.
+             *)
+            None)
+    in
+
+    let rec t =
+      lazy
+        (let stream =
+           match body_length with
+           | `Fixed 0L -> Stream.empty ()
+           | _ -> Stream.from ~f:(read_fn t)
+         in
+         { stream; error_received = default_error_received; read_counter = 0 })
+    in
+    Lazy.force t
+
+  let to_t
+      : type a.
+        (module Reader with type t = a)
+        -> ?on_eof:(body_stream -> unit)
+        -> body_length:length
+        -> a
+        -> t
+    =
+   fun (module Reader) ?on_eof ~body_length body ->
+    let stream = to_stream (module Reader) ?on_eof ~body_length body in
+    create ~length:body_length (`Stream stream)
+
+  let flush_and_close
+      : type a. (module Writer with type t = a) -> a -> (unit -> unit) -> unit
+    =
+   fun (module Writer) body f ->
+    Writer.close body;
+    Writer.flush body f
+
+  let stream_write_body
+      : type a.
+        (module Writer with type t = a)
+        -> a
+        -> Bigstringaf.t IOVec.t Stream.t
+        -> unit
+    =
+   fun (module Writer) body stream ->
+    Stream.iter
+      ~f:(fun { IOVec.buffer; off; len } ->
+        (* If the peer left abruptly the connection will be shutdown. Avoid
+         * crashing the server with exceptions related to the writer being
+         * closed. *)
+        if not (Writer.is_closed body)
+        then (
+          Writer.schedule_bigstring body ~off ~len buffer;
+          let p, u = Promise.create () in
+          Writer.flush body (fun () ->
+              Promise.resolve u ();
+              Log.debug (fun m -> m "Flushed output chunk of length %d" len));
+          Promise.await p)
+        else ())
+      stream;
+    flush_and_close (module Writer) body ignore
 end
-
-let embed_error_received t error_received = t.error_received <- error_received
-
-let of_raw_body
-    : type a.
-      (module BODY with type Reader.t = a)
-      -> ?on_eof:(t -> unit)
-      -> body_length:length
-      -> a
-      -> t
-  =
- fun (module Http_body) ?on_eof ~body_length body ->
-  let module Body = Http_body.Reader in
-  let read_fn t () =
-    let t = Lazy.force t in
-    let p, u = Promise.create () in
-    let on_read_direct buffer ~off ~len =
-      Promise.resolve u (Some (IOVec.make buffer ~off ~len))
-    and on_read_with_yield buffer ~off ~len =
-      Fiber.yield ();
-      Promise.resolve u (Some (IOVec.make buffer ~off ~len))
-    in
-    t.read_counter <- t.read_counter + 1;
-    let on_read =
-      if t.read_counter > 128
-      then (
-        t.read_counter <- 0;
-        on_read_with_yield)
-      else on_read_direct
-    in
-    Body.schedule_read
-      body
-      ~on_eof:(fun () ->
-        Option.iter (fun f -> f t) on_eof;
-        Body.close body;
-        Promise.resolve u None)
-      ~on_read;
-    Fiber.first
-      (fun () -> Promise.await p)
-      (fun () ->
-        match Promise.await t.error_received with
-        | (_ : Error.t) ->
-          (* `None` closes the stream. The promise `t.error_received` remains
-           * fulfilled, which signals that the stream hasn't closed cleanly.
-           *)
-          None)
-  in
-
-  let rec t =
-    lazy
-      (let stream =
-         match body_length with
-         | `Fixed 0L -> Stream.empty ()
-         | _ -> Stream.from ~f:(read_fn t)
-       in
-       of_stream ~length:body_length stream)
-  in
-  Lazy.force t
-
-let flush_and_close
-    : type a.
-      (module BODY with type Writer.t = a) -> a -> (unit -> unit) -> unit
-  =
- fun (module B) body f ->
-  let module Body = B.Writer in
-  Body.close body;
-  Body.flush body f
-
-let stream_write_body
-    : type a.
-      (module BODY with type Writer.t = a)
-      -> a
-      -> Bigstringaf.t IOVec.t Stream.t
-      -> unit
-  =
- fun (module B) body stream ->
-  let module Body = B.Writer in
-  Stream.iter
-    ~f:(fun { IOVec.buffer; off; len } ->
-      (* If the peer left abruptly the connection will be shutdown. Avoid
-       * crashing the server with exceptions related to the writer being
-       * closed. *)
-      if not (Body.is_closed body)
-      then (
-        Body.schedule_bigstring body ~off ~len buffer;
-        let p, u = Promise.create () in
-        Body.flush body (fun () ->
-            Promise.resolve u ();
-            Log.debug (fun m -> m "Flushed output chunk of length %d" len));
-        Promise.await p)
-      else ())
-    stream;
-  flush_and_close (module B) body ignore
 
 (* Traversal *)
 let fold ~f ~init t =
   let stream = to_stream t in
   let ret = Stream.fold ~f ~init stream in
-  or_error t ~stream ret
+  or_error ~error_p:(error_p t.contents) ~stream ret
 
 let fold_string ~f ~init t =
   let stream = to_string_stream t in
   let ret = Stream.fold ~f ~init stream in
-  or_error t ~stream ret
+  or_error ~error_p:(error_p t.contents) ~stream ret
 
 let iter ~f t =
   let stream = to_stream t in
   Stream.iter ~f stream;
-  or_error t ~stream ()
+  or_error ~error_p:(error_p t.contents) ~stream ()
 
 let iter_string ~f t =
   let stream = to_string_stream t in
   Stream.iter ~f stream;
-  or_error t ~stream ()
+  or_error ~error_p:(error_p t.contents) ~stream ()
 
 let iter_p ~sw ~f t =
   let stream = to_stream t in
   Stream.iter_p ~sw ~f stream;
-  or_error t ~stream ()
+  or_error ~error_p:(error_p t.contents) ~stream ()
 
 let iter_string_p ~sw ~f t =
   let stream = to_string_stream t in
   Stream.iter_p ~sw ~f stream;
-  or_error t ~stream ()
+  or_error ~error_p:(error_p t.contents) ~stream ()
 
 let to_list t =
   let stream = to_stream t in
@@ -433,23 +469,3 @@ let to_list t =
 let to_string_list t =
   let stream = to_string_stream t in
   Stream.to_list stream
-
-(* let iter_s f t = *)
-(* let* stream, or_error = to_stream t in *)
-(* let* () = Lwt_stream.iter_s f stream in *)
-(* or_error *)
-
-(* let iter_string_s f t = *)
-(* let* stream, or_error = to_string_stream t in *)
-(* let* () = Lwt_stream.iter_s f stream in *)
-(* or_error *)
-
-(* let iter_n ?max_concurrency f t = *)
-(* let* stream, or_error = to_stream t in *)
-(* let* () = Lwt_stream.iter_n ?max_concurrency f stream in *)
-(* or_error *)
-
-(* let iter_string_n ?max_concurrency f t = *)
-(* let* stream, or_error = to_string_stream t in *)
-(* let* () = Lwt_stream.iter_n ?max_concurrency f stream in *)
-(* or_error *)

--- a/lib/client.ml
+++ b/lib/client.ml
@@ -486,6 +486,23 @@ let patch t ?headers ?body target =
 
 let delete t ?headers ?body target = call t ?headers ?body ~meth:`DELETE target
 
+let ws_upgrade
+    :  t -> ?headers:(string * string) list -> string
+    -> (Ws.Descriptor.t, Error.t) result
+  =
+ fun t ?(headers = []) target ->
+  let (Conn { info; _ }) = t.conn in
+  let request =
+    Ws.upgrade_request
+      ~headers:(Httpaf.Headers.of_list headers)
+      ~scheme:info.scheme
+      ~nonce:"0123456789ABCDEF"
+      target
+  in
+  let*! response = send t request in
+  let*! () = Body.drain response.body in
+  (Http_impl.upgrade_connection ~sw:t.sw t.conn :> (_, Error.t) result)
+
 module Oneshot = struct
   (* Note: we're not sending `Connection: close`:
    * - HTTP/2 doesn't support the `Connection` header

--- a/lib/client.ml
+++ b/lib/client.ml
@@ -53,16 +53,14 @@ let create_http_connection ~sw ~config ~conn_info ~uri fd =
       , config.max_http_version
       , config.h2c_upgrade )
     with
-    | true, _, _ -> (module Http2.HTTP : Http_intf.HTTP), Versions.HTTP.v2_0
-    | false, HTTP_2, true ->
-      (module Http1.HTTP : Http_intf.HTTP), Versions.HTTP.v1_1
+    | true, _, _ -> (module Http2.HTTP : Http_intf.HTTP), Versions.HTTP.HTTP_2
+    | false, HTTP_2, true -> (module Http1.HTTP : Http_intf.HTTP), HTTP_1_1
     | false, _, _ ->
       let version =
-        if Versions.HTTP.(
-             compare (Versions.ALPN.to_version config.max_http_version) v2_0)
+        if Versions.HTTP.Raw.(compare (of_version config.max_http_version) v2_0)
            >= 0
-        then Versions.HTTP.v1_1
-        else Versions.ALPN.to_version config.max_http_version
+        then Versions.HTTP.HTTP_1_1
+        else config.max_http_version
       in
       (module Http1.HTTP : Http_intf.HTTP), version
   in
@@ -108,26 +106,25 @@ let create_https_connection
        * version configured. *)
       let impl, version =
         if config.http2_prior_knowledge
-        then (module Http2.HTTPS : Http_intf.HTTPS), Versions.HTTP.v2_0
+        then (module Http2.HTTPS : Http_intf.HTTPS), Versions.HTTP.HTTP_2
         else
           ( (module Http1.HTTPS : Http_intf.HTTPS)
-          , if Versions.HTTP.(
-                 compare (Versions.ALPN.to_version config.max_http_version) v2_0)
+          , if Versions.HTTP.Raw.(
+                 compare (of_version config.max_http_version) v2_0)
                >= 0
-            then Versions.HTTP.v1_1
-            else Versions.ALPN.to_version config.max_http_version )
+            then HTTP_1_1
+            else config.max_http_version )
       in
-      Log.info (fun m -> m "Defaulting to %a" Versions.HTTP.pp_hum version);
+      Log.info (fun m -> m "Defaulting to %a" Versions.HTTP.pp version);
       impl, version
     | Some negotiated_proto ->
       Log.info (fun m -> m "ALPN: server agreed to use %s" negotiated_proto);
       (match Versions.ALPN.of_string negotiated_proto with
-      | Some HTTP_1_0 ->
-        (module Http1.HTTPS : Http_intf.HTTPS), Versions.HTTP.v1_0
-      | Some HTTP_1_1 ->
-        (module Http1.HTTPS : Http_intf.HTTPS), Versions.HTTP.v1_1
-      | Some HTTP_2 ->
-        (module Http2.HTTPS : Http_intf.HTTPS), Versions.HTTP.v2_0
+      | Some version ->
+        ( (match version with
+          | HTTP_1_0 | HTTP_1_1 -> (module Http1.HTTPS : Http_intf.HTTPS)
+          | HTTP_2 -> (module Http2.HTTPS : Http_intf.HTTPS))
+        , version )
       | None ->
         (* Can't really happen - would mean that TLS negotiated a
          * protocol that we didn't specify. *)
@@ -277,7 +274,7 @@ let rec return_response
   match request_info.is_h2c_upgrade, scheme, version, status, config with
   | ( true
     , `HTTP
-    , { Versions.HTTP.major = 1; minor = 1 }
+    , HTTP_1_1
     , `Switching_protocols
     , { Config.h2c_upgrade = true
       ; max_http_version = HTTP_2
@@ -316,10 +313,7 @@ let is_h2c_upgrade ~config ~version ~scheme =
     , config.h2c_upgrade
     , scheme )
   with
-  | false, cur_version, max_version, true, `HTTP ->
-    Versions.HTTP.(
-      equal (Versions.ALPN.to_version max_version) v2_0
-      && equal cur_version v1_1)
+  | false, Versions.HTTP.HTTP_1_1, HTTP_2, true, `HTTP -> true
   | _ -> false
 
 let make_request_info

--- a/lib/client.ml
+++ b/lib/client.ml
@@ -486,11 +486,16 @@ let ws_upgrade
   =
  fun t ?(headers = []) target ->
   let (Conn { info; _ }) = t.conn in
+  (* From RFC6455§4.1:
+   *   The value of this header field MUST be a nonce consisting of a randomly
+   *   selected 16-byte value that has been base64-encoded (see Section 4 of
+   *   [RFC4648]). The nonce MUST be selected randomly for each connection. *)
+  let nonce = Openssl.random_string 16 in
   let request =
     Ws.upgrade_request
       ~headers:(Httpaf.Headers.of_list headers)
       ~scheme:info.scheme
-      ~nonce:"0123456789ABCDEF"
+      ~nonce
       target
   in
   let*! response = send t request in

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -47,7 +47,7 @@ type t =
         (** max redirects to follow. Could probably be rolled up into one option *)
   ; allow_insecure : bool
         (** Wether to allow insecure server connections when using SSL *)
-  ; max_http_version : Versions.ALPN.t
+  ; max_http_version : Versions.HTTP.t
         (** Use this as the highest HTTP version when sending requests *)
   ; h2c_upgrade : bool
         (** Send an upgrade to `h2c` (HTTP/2 over TCP) request to the server.
@@ -88,7 +88,7 @@ let default =
   { follow_redirects = false
   ; max_redirects = 10
   ; allow_insecure = false
-  ; max_http_version = Versions.ALPN.HTTP_2
+  ; max_http_version = Versions.HTTP.HTTP_2
   ; http2_prior_knowledge = false
   ; h2c_upgrade = false
   ; cacert = None

--- a/lib/connection.ml
+++ b/lib/connection.ml
@@ -167,7 +167,6 @@ type t =
       ; mutable persistent : bool
       ; runtime : Gluten_eio.Client.t
       ; connection_error_received : Error.client Promise.t
-      ; version : Versions.HTTP.t
-            (** HTTP version that this connection speaks *)
+      ; version : Versions.HTTP.t (* HTTP version that this connection speaks *)
       }
       -> t

--- a/lib/dune
+++ b/lib/dune
@@ -9,8 +9,8 @@
   h2-eio
   httpaf
   httpaf-eio
+  digestif
   websocketaf
-  websocketaf-eio
   logs
   eio
   eio-ssl

--- a/lib/dune
+++ b/lib/dune
@@ -9,6 +9,8 @@
   h2-eio
   httpaf
   httpaf-eio
+  websocketaf
+  websocketaf-eio
   logs
   eio
   eio-ssl

--- a/lib/dune
+++ b/lib/dune
@@ -22,4 +22,4 @@
   piaf.stream)
  (foreign_stubs
   (language c)
-  (names piaf_bigarray_read piaf_fdutils)))
+  (names piaf_bigarray_read piaf_openssl_rand piaf_fdutils)))

--- a/lib/error.ml
+++ b/lib/error.ml
@@ -7,6 +7,7 @@ type common =
   [ `Exn of exn
   | `Protocol_error of H2.Error_code.t * string
   | `TLS_error of string
+  | `Upgrade_not_supported
   | `Msg of string
   ]
 
@@ -52,6 +53,7 @@ let to_string = function
   | `Bad_gateway -> "Bad Gateway"
   | `Bad_request -> "Bad Request"
   | `Internal_server_error -> "Internal Server Error"
+  | `Upgrade_not_supported -> "Upgrades not supported in this HTTP Version"
   | `Msg string -> string
 
 let pp_hum formatter t = Format.fprintf formatter "%s" (to_string t)

--- a/lib/headers.ml
+++ b/lib/headers.ml
@@ -74,23 +74,21 @@ let add_length_related_headers ~body_length headers =
 let canonicalize_headers ~body_length ~host ~version headers =
   let headers =
     match version with
-    | { Versions.HTTP.major = 2; _ } ->
+    | Versions.HTTP.HTTP_2 ->
       of_list
         ((Well_known.HTTP2.host, host)
         :: List.map
              (fun (name, value) -> String.lowercase_ascii name, value)
              headers)
-    | { major = 1; _ } ->
+    | HTTP_1_0 | HTTP_1_1 ->
       add_unless_exists (of_list headers) Well_known.HTTP1.host host
-    | _ -> failwith "unsupported version"
   in
   add_length_related_headers ~body_length headers
 
 let host t ~version =
   match version with
-  | { Versions.HTTP.major = 2; _ } -> get t Well_known.HTTP2.host
-  | { major = 1; _ } -> get t Well_known.HTTP1.host
-  | _ -> None
+  | Versions.HTTP.HTTP_2 -> get t Well_known.HTTP2.host
+  | HTTP_1_0 | HTTP_1_1 -> get t Well_known.HTTP1.host
 
 let of_http1 headers = of_rev_list (Httpaf.Headers.to_rev_list headers)
 let to_http1 headers = Httpaf.Headers.of_rev_list (to_rev_list headers)

--- a/lib/http1.ml
+++ b/lib/http1.ml
@@ -32,7 +32,7 @@
 open Eio.Std
 module Piaf_body = Body
 
-module type BODY = Body.BODY
+module type BODY = Body.Raw.BODY
 
 module Body :
   BODY
@@ -91,8 +91,9 @@ module MakeHTTP1 (Runtime_scheme : Scheme.Runtime.SCHEME) :
         (* TODO: revisit whether this is necessary. *)
         if request_method = `HEAD then Body.Reader.close body;
         let body =
-          Piaf_body.of_raw_body
-            (module Body : BODY with type Reader.t = Httpaf.Body.Reader.t)
+          Piaf_body.Raw.to_t
+            (module Body.Reader : Piaf_body.Raw.Reader
+              with type t = Httpaf.Body.Reader.t)
             ~body_length:
               (Httpaf.Response.body_length ~request_method response
                 :> Piaf_body.length)
@@ -177,15 +178,14 @@ module MakeHTTP1 (Runtime_scheme : Scheme.Runtime.SCHEME) :
       let request = Httpaf.Reqd.request reqd in
       let body_length = Httpaf.Request.body_length request in
       let request_body =
-        Piaf_body.of_raw_body
-          (module Body : BODY with type Reader.t = Httpaf.Body.Reader.t)
+        Piaf_body.Raw.to_t
+          (module Body.Reader : Piaf_body.Raw.Reader
+            with type t = Httpaf.Body.Reader.t)
           ~body_length:(body_length :> Piaf_body.length)
-          ~on_eof:(fun body ->
+          ~on_eof:(fun t ->
             match Httpaf.Reqd.error_code reqd with
             | Some error ->
-              Piaf_body.embed_error_received
-                body
-                (Promise.create_resolved (error :> Error.t))
+              t.error_received <- Promise.create_resolved (error :> Error.t)
             | None -> ())
           (Httpaf.Reqd.request_body reqd)
       in

--- a/lib/http1.ml
+++ b/lib/http1.ml
@@ -201,7 +201,7 @@ module MakeHTTP1 (Runtime_scheme : Scheme.Runtime.SCHEME) :
           ~upgrade
           ~fd
           ~scheme:Runtime_scheme.scheme
-          ~version:Versions.ALPN.HTTP_1_1
+          ~version:HTTP_1_1
           ~handler
           ~client_address:client_addr
           reqd

--- a/lib/http2.ml
+++ b/lib/http2.ml
@@ -42,7 +42,7 @@ let make_client_error_handler real_handler type_ error =
 
 module Piaf_body = Body
 
-module type BODY = Body.BODY
+module type BODY = Body.Raw.BODY
 
 module Body :
   BODY
@@ -107,8 +107,9 @@ end = struct
           | `Other _ -> `GET
         in
         let body =
-          Piaf_body.of_raw_body
-            (module Body : BODY with type Reader.t = H2.Body.Reader.t)
+          Piaf_body.Raw.to_t
+            (module Body.Reader : Piaf_body.Raw.Reader
+              with type t = H2.Body.Reader.t)
             ~body_length:
               (H2.Response.body_length ~request_method response
                 :> Piaf_body.length)
@@ -182,15 +183,14 @@ end = struct
     let request = H2.Reqd.request reqd in
     let body_length = H2.Request.body_length request in
     let request_body =
-      Piaf_body.of_raw_body
-        (module Body : BODY with type Reader.t = H2.Body.Reader.t)
+      Piaf_body.Raw.to_t
+        (module Body.Reader : Piaf_body.Raw.Reader
+          with type t = H2.Body.Reader.t)
         ~body_length:(body_length :> Piaf_body.length)
-        ~on_eof:(fun body ->
+        ~on_eof:(fun t ->
           match H2.Reqd.error_code reqd with
           | Some error ->
-            Piaf_body.embed_error_received
-              body
-              (Promise.create_resolved (error :> Error.t))
+            t.error_received <- Promise.create_resolved (error :> Error.t)
           | None -> ())
         (H2.Reqd.request_body reqd)
     in
@@ -263,8 +263,9 @@ module HTTP : Http_intf.HTTP2 with type scheme = Scheme.http = struct
           | `Other _ -> `GET
         in
         let body =
-          Piaf_body.of_raw_body
-            (module Body : BODY with type Reader.t = H2.Body.Reader.t)
+          Piaf_body.Raw.to_t
+            (module Body.Reader : Piaf_body.Raw.Reader
+              with type t = H2.Body.Reader.t)
             ~body_length:
               (H2.Response.body_length ~request_method response
                 :> Piaf_body.length)

--- a/lib/http2.ml
+++ b/lib/http2.ml
@@ -205,7 +205,7 @@ end = struct
         (module HttpServer)
         ~fd
         ~scheme:Runtime_scheme.scheme
-        ~version:Versions.ALPN.HTTP_1_1
+        ~version:HTTP_1_1
         ~handler
         ~client_address:client_addr
         reqd

--- a/lib/http_impl.ml
+++ b/lib/http_impl.ml
@@ -191,7 +191,6 @@ let send_request
           assert false));
   handle_response ~sw response_received error_received connection_error_received
 
-(* TODO: Don't upgrade if we're speaking HTTP/2 *)
 let upgrade_connection
     : sw:Switch.t -> Connection.t -> (Ws.Descriptor.t, Error.client) result
   =
@@ -200,7 +199,7 @@ let upgrade_connection
     conn
   in
   match version with
-  | HTTP_1_0 | HTTP_2 -> assert false
+  | HTTP_1_0 | HTTP_2 -> Error `Upgrade_not_supported
   | HTTP_1_1 ->
     let wsd_received, notify_wsd = Promise.create () in
     let error_received, notify_error = Promise.create () in

--- a/lib/http_intf.ml
+++ b/lib/http_intf.ml
@@ -97,13 +97,13 @@ module type HTTPCommon = sig
 
   val scheme : Scheme.t
 
-  module Body : Body.BODY
+  module Body : Body.Raw.BODY
   module Client : Client with type write_body := Body.Writer.t
   module Server : Server with type write_body := Body.Writer.t
 end
 
 module type HTTPServerCommon = sig
-  module Body : Body.BODY
+  module Body : Body.Raw.BODY
   module Reqd : Reqd with type write_body := Body.Writer.t
 end
 
@@ -112,14 +112,8 @@ module type HTTP1 = sig
 
   val scheme : Scheme.t
 
-  module Body : Body.BODY
-
-  module Client : sig
-    include Client with type write_body := Body.Writer.t
-
-    val upgrade : t -> Gluten.impl -> unit
-  end
-
+  module Body : Body.Raw.BODY
+  module Client : Client with type write_body := Body.Writer.t
   module Server : Server with type write_body := Body.Writer.t
 end
 
@@ -134,7 +128,7 @@ module type HTTP2 = sig
 
   val scheme : Scheme.t
 
-  module Body : Body.BODY
+  module Body : Body.Raw.BODY
 
   module Client : sig
     include Client with type write_body := Body.Writer.t

--- a/lib/http_server_impl.ml
+++ b/lib/http_server_impl.ml
@@ -31,7 +31,7 @@ type t =
       ; handle : Eio.Flow.two_way
       ; scheme : Scheme.t
             (* ; connection_error_received : Error.server Promise.t *)
-      ; version : Versions.ALPN.t
+      ; version : Versions.HTTP.t
             (** HTTP version that this connection speaks *)
       ; upgrade : upgrade option
       ; handler : Request_info.t Server_intf.Handler.t
@@ -45,7 +45,7 @@ let create_descriptor
       -> (module Http_intf.HTTPServerCommon with type Reqd.t = reqd)
       -> fd:Eio.Flow.two_way
       -> scheme:Scheme.t
-      -> version:Versions.ALPN.t
+      -> version:Versions.HTTP.t
       -> handler:Request_info.t Server_intf.Handler.t
       -> client_address:Eio.Net.Sockaddr.stream
       -> reqd

--- a/lib/http_server_impl.ml
+++ b/lib/http_server_impl.ml
@@ -136,7 +136,7 @@ let handle_request : sw:Switch.t -> t -> Request.t -> unit =
           in
           (match Piaf_body.contents body with
           | `Empty upgrade_handler ->
-            if Piaf_body.Optional_handler.is_none upgrade_handler
+            if Piaf_body.Optional_upgrade_handler.is_none upgrade_handler
             then
               (* No upgrade *)
               Http.Reqd.respond_with_bigstring reqd response Bigstringaf.empty
@@ -146,7 +146,8 @@ let handle_request : sw:Switch.t -> t -> Request.t -> unit =
               match upgrade with
               | Some upgrade ->
                 Http.Reqd.respond_with_upgrade reqd response.headers (fun () ->
-                    Piaf_body.Optional_handler.call_if_some
+                    Piaf_body.Optional_upgrade_handler.call_if_some
+                      ~sw
                       upgrade_handler
                       upgrade)
               | None ->

--- a/lib/message.ml
+++ b/lib/message.ml
@@ -36,5 +36,6 @@ let persistent_connection version headers =
   (* XXX: technically HTTP/2 HEADERS frames shouldn't have `connection` headers,
    * but that's enforced upstream in H2. *)
   | "close" -> false
-  | "keep-alive" -> Version.(compare version v1_0) >= 0
-  | _ | (exception Not_found) -> Version.(compare version v1_1) >= 0
+  | "keep-alive" -> true
+  | _ | (exception Not_found) ->
+    (match version with Version.HTTP_1_0 -> false | HTTP_1_1 | HTTP_2 -> true)

--- a/lib/openssl.ml
+++ b/lib/openssl.ml
@@ -241,53 +241,22 @@ let set_client_verify ?cacert ?capath ~clientcert ctx =
   | Some (certificate, private_key) -> load_cert ~certificate ~private_key ctx
   | None -> Ok ()
 
-module Client_conf = struct
-  type t =
-    { min_tls_version : Versions.TLS.t
-    ; max_tls_version : Versions.TLS.t
-    ; alpn_protocols : string list
-    ; allow_insecure : bool
-    ; cacert : Cert.t option
-    ; capath : string option
-    ; clientcert : (Cert.t * Cert.t) option
-    }
-
-  let of_config
-      { Config.min_tls_version
-      ; max_tls_version
-      ; max_http_version
-      ; allow_insecure
-      ; cacert
-      ; capath
-      ; clientcert
-      ; _
-      }
-    =
-    let alpn_protocols = Versions.ALPN.protocols_of_version max_http_version in
-    { min_tls_version
-    ; max_tls_version
-    ; alpn_protocols
-    ; allow_insecure
-    ; cacert
-    ; capath
-    ; clientcert
-    }
-end
-
 let setup_client_ctx
     ~config:
-      Client_conf.
+      Config.
         { min_tls_version
         ; max_tls_version
-        ; alpn_protocols
         ; allow_insecure
         ; cacert
         ; capath
         ; clientcert
+        ; max_http_version
+        ; _
         }
     ~hostname
     fd
   =
+  let alpn_protocols = Versions.ALPN.protocols_of_version max_http_version in
   match
     Ssl.(
       create_context
@@ -333,10 +302,10 @@ let setup_client_ctx
 
 (* Assumes that the file descriptor is connected. *)
 let connect ~hostname ~config fd =
-  let ({ Client_conf.allow_insecure; min_tls_version; max_tls_version; _ } as
+  let ({ Config.allow_insecure; min_tls_version; max_tls_version; _ } as
       client_conf)
     =
-    Client_conf.of_config config
+    config
   in
   if Versions.TLS.compare min_tls_version max_tls_version > 0
   then (
@@ -387,44 +356,6 @@ let connect ~hostname ~config fd =
             m "%a" (pp_cert_verify_result ~allow_insecure) verify_result));
       Error e
 
-module Server_conf = struct
-  type t =
-    { allow_insecure : bool
-    ; max_http_version : Versions.HTTP.t
-    ; cacert : Cert.t option
-    ; capath : string option
-    ; certificate : Cert.t * Cert.t (* cert, priv_key *)
-    ; enforce_client_cert : bool
-    ; min_tls_version : Versions.TLS.t
-    ; max_tls_version : Versions.TLS.t
-    ; accept_timeout : float (* seconds *)
-    }
-
-  let of_server_config
-      ~https:
-        { Server_config.HTTPS.allow_insecure
-        ; cacert
-        ; capath
-        ; certificate
-        ; enforce_client_cert
-        ; min_tls_version
-        ; max_tls_version
-        ; _
-        }
-    = function
-    | { Server_config.max_http_version; accept_timeout; _ } ->
-      { allow_insecure
-      ; max_http_version
-      ; cacert
-      ; capath
-      ; certificate
-      ; enforce_client_cert
-      ; min_tls_version
-      ; max_tls_version
-      ; accept_timeout
-      }
-end
-
 let set_server_verify ~enforce_client_cert ctx =
   (* TODO(anmonteiro): enable if Logs.Debug? *)
   Ssl.set_client_verify_callback_verbose true;
@@ -445,17 +376,17 @@ let rec first_match l1 = function
 
 let setup_server_ctx
     ~config:
-      Server_conf.
+      Server_config.HTTPS.
         { min_tls_version
         ; max_tls_version
         ; allow_insecure
         ; cacert
         ; capath
         ; certificate = certificate, private_key
-        ; max_http_version
         ; enforce_client_cert
         ; _
         }
+    ~max_http_version
   =
   let alpn_protocols = Versions.ALPN.protocols_of_version max_http_version in
   match
@@ -511,12 +442,17 @@ type accept =
 
 (* TODO(anmonteiro): if we wanna support multiple hostnames, this is how to do
    SNI: https://stackoverflow.com/a/5113466/3417023 *)
-let accept ~clock ~(config : Server_conf.t) ~fd =
-  let*! ctx = setup_server_ctx ~config in
+let accept
+    ~clock
+    ~(config : Server_config.HTTPS.t)
+    ~max_http_version
+    ~timeout
+    fd
+  =
+  let*! ctx = setup_server_ctx ~config ~max_http_version in
   let ssl_ctx = Eio_ssl.Context.create ~ctx fd in
   match
-    Eio.Time.with_timeout clock config.accept_timeout (fun () ->
-        Ok (Eio_ssl.accept ssl_ctx))
+    Eio.Time.with_timeout clock timeout (fun () -> Ok (Eio_ssl.accept ssl_ctx))
   with
   | Ok ssl_server ->
     let alpn_version = get_negotiated_alpn_protocol ssl_server in

--- a/lib/openssl.ml
+++ b/lib/openssl.ml
@@ -67,7 +67,9 @@ module Time = struct
       year
 end
 
-let () = Ssl.init ~thread_safe:true ()
+let () = Ssl.init ()
+
+external random_string : int -> string = "piaf_random_bytes"
 
 let pp_cert_verify_result ~allow_insecure formatter verify_result =
   let verify_error_string = Ssl.get_verify_error_string verify_result in

--- a/lib/openssl.ml
+++ b/lib/openssl.ml
@@ -390,7 +390,7 @@ let connect ~hostname ~config fd =
 module Server_conf = struct
   type t =
     { allow_insecure : bool
-    ; max_http_version : Versions.ALPN.t
+    ; max_http_version : Versions.HTTP.t
     ; cacert : Cert.t option
     ; capath : string option
     ; certificate : Cert.t * Cert.t (* cert, priv_key *)
@@ -496,8 +496,8 @@ let setup_server_ctx
 let get_negotiated_alpn_protocol ssl_server =
   let ssl_socket = Eio_ssl.ssl_socket ssl_server in
   match Ssl.get_negotiated_alpn_protocol ssl_socket with
-  | Some "http/1.1" -> Versions.ALPN.HTTP_1_1
-  | Some "h2" -> Versions.ALPN.HTTP_2
+  | Some "http/1.1" -> Versions.HTTP.HTTP_1_1
+  | Some "h2" -> HTTP_2
   | None (* Unable to negotiate a protocol *) | Some _ ->
     (* Can't really happen - would mean that TLS negotiated a
      * protocol that we didn't specify. *)
@@ -506,7 +506,7 @@ let get_negotiated_alpn_protocol ssl_server =
 
 type accept =
   { socket : Eio_ssl.t
-  ; alpn_version : Versions.ALPN.t
+  ; alpn_version : Versions.HTTP.t
   }
 
 (* TODO(anmonteiro): if we wanna support multiple hostnames, this is how to do

--- a/lib/piaf.ml
+++ b/lib/piaf.ml
@@ -47,3 +47,4 @@ module Status = Status
 module Versions = Versions
 module Server = Server
 module Cookies = Cookies
+module Ws = Ws

--- a/lib/piaf.mli
+++ b/lib/piaf.mli
@@ -317,6 +317,7 @@ module Error : sig
     [ `Exn of exn
     | `Protocol_error of H2.Error_code.t * string
     | `TLS_error of string
+    | `Upgrade_not_supported
     | `Msg of string
     ]
 
@@ -536,7 +537,7 @@ module Response : sig
       :  f:(Ws.Descriptor.t -> unit)
       -> ?headers:Headers.t
       -> Request.t
-      -> t
+      -> (t, Error.t) result
   end
 
   val or_internal_error : (t, Error.t) result -> t

--- a/lib/posix.ml
+++ b/lib/posix.ml
@@ -35,7 +35,7 @@ module Log = (val Logs.src_log src : Logs.LOG)
 
 let sendfile
     (type a)
-    (module Bodyw : Body.BODY with type Writer.t = a)
+    (module Writer : Body.Raw.Writer with type t = a)
     ~src_fd
     ~dst_fd
     raw_write_body
@@ -53,5 +53,5 @@ let sendfile
     Log.debug (fun m -> m "`sendfile` wrote %d bytes successfully" sent);
     Ok ()
   | Error e ->
-    Bodyw.Writer.close raw_write_body;
+    Writer.close raw_write_body;
     Error (Unix.Unix_error (e, "sendfile", "") (* TODO(anmonteiro): log err *))

--- a/lib/request_info.ml
+++ b/lib/request_info.ml
@@ -1,5 +1,5 @@
 type t =
   { scheme : Scheme.t
-  ; version : Versions.ALPN.t
+  ; version : Versions.HTTP.t
   ; client_address : Eio.Net.Sockaddr.stream
   }

--- a/lib/response.ml
+++ b/lib/response.ml
@@ -104,43 +104,49 @@ module Upgrade = struct
       `Switching_protocols
 
   let websocket ~f ?(headers = Headers.empty) (request : Request.t) =
-    let wsd_received, notify_wsd = Promise.create () in
-    let _error_received, notify_error = Promise.create () in
-    let upgrade_handler ~sw upgrade =
-      let error_handler _wsd error =
-        Promise.resolve notify_error (error :> Error.client)
+    match request.version with
+    | HTTP_1_0 | HTTP_2 -> Error `Upgrade_not_supported
+    | HTTP_1_1 ->
+      let wsd_received, notify_wsd = Promise.create () in
+      let _error_received, notify_error = Promise.create () in
+      let upgrade_handler ~sw upgrade =
+        let error_handler _wsd error =
+          Promise.resolve notify_error (error :> Error.client)
+        in
+
+        let ws_conn =
+          Websocketaf.Server_connection.create_websocket
+            ~error_handler
+            (Ws.Handler.websocket_handler ~sw ~notify_wsd)
+        in
+        Fiber.fork ~sw (fun () -> f (Promise.await wsd_received));
+        upgrade (Gluten.make (module Websocketaf.Server_connection) ws_conn)
       in
 
-      let ws_conn =
-        Websocketaf.Server_connection.create_websocket
-          ~error_handler
-          (Ws.Handler.websocket_handler ~sw ~notify_wsd)
+      let httpaf_headers = Headers.to_http1 request.headers in
+      let sha1 s =
+        let open Digestif in
+        s |> SHA1.digest_string |> SHA1.to_raw_string
       in
-      Fiber.fork ~sw (fun () -> f (Promise.await wsd_received));
-      upgrade (Gluten.make (module Websocketaf.Server_connection) ws_conn)
-    in
 
-    let httpaf_headers = Headers.to_http1 request.headers in
-    let sha1 s =
-      let open Digestif in
-      s |> SHA1.digest_string |> SHA1.to_raw_string
-    in
-
-    match
-      Websocketaf.Handshake.upgrade_headers
-        ~sha1
-        ~request_method:request.meth
-        httpaf_headers
-    with
-    | Ok upgrade_headers ->
-      generic
-        ~headers:Headers.(add_list (of_list upgrade_headers) (to_list headers))
-        upgrade_handler
-    | Error err_str ->
-      of_string
-        ~body:err_str
-        ~headers:Headers.(of_list Well_known.[ connection, Values.close ])
-        `Bad_request
+      (match
+         Websocketaf.Handshake.upgrade_headers
+           ~sha1
+           ~request_method:request.meth
+           httpaf_headers
+       with
+      | Ok upgrade_headers ->
+        Ok
+          (generic
+             ~headers:
+               Headers.(add_list (of_list upgrade_headers) (to_list headers))
+             upgrade_handler)
+      | Error err_str ->
+        Ok
+          (of_string
+             ~body:err_str
+             ~headers:Headers.(of_list Well_known.[ connection, Values.close ])
+             `Bad_request))
 end
 
 let of_http1 ?(body = Body.empty) response =

--- a/lib/server.ml
+++ b/lib/server.ml
@@ -81,7 +81,7 @@ let is_requesting_h2c_upgrade ~config ~version ~scheme headers =
 
 let do_h2c_upgrade ~sw ~fd ~request_body server =
   let { config; error_handler; handler } = server in
-  let upgrade_handler client_address (request : Request.t) upgrade =
+  let upgrade_handler ~sw:_ client_address (request : Request.t) upgrade =
     let http_request =
       Httpaf.Request.create
         ~headers:
@@ -108,7 +108,7 @@ let do_h2c_upgrade ~sw ~fd ~request_body server =
       Headers.(
         of_list [ Well_known.connection, "Upgrade"; Well_known.upgrade, "h2c" ])
     in
-    Response.upgrade ~headers (upgrade_handler client_address request)
+    Response.Upgrade.generic ~headers (upgrade_handler client_address request)
   in
   request_handler
 

--- a/lib/server.ml
+++ b/lib/server.ml
@@ -144,9 +144,15 @@ let http_connection_handler t : connection_handler =
 
 let https_connection_handler ~https ~clock t : connection_handler =
   let { error_handler; handler; config } = t in
-  let ssl_config = Openssl.Server_conf.of_server_config ~https config in
   fun ~sw socket client_address ->
-    match Openssl.accept ~clock ~config:ssl_config ~fd:socket with
+    match
+      Openssl.accept
+        ~clock
+        ~config:https
+        ~max_http_version:config.max_http_version
+        ~timeout:config.accept_timeout
+        socket
+    with
     | Error (`Exn exn) -> Format.eprintf "EXN: %s@." (Printexc.to_string exn)
     | Error (`Connect_error string) ->
       Format.eprintf "CONNECT ERROR: %s@." string

--- a/lib/server_config.ml
+++ b/lib/server_config.ml
@@ -41,7 +41,7 @@ end
 
 type t =
   { port : int
-  ; max_http_version : Versions.ALPN.t
+  ; max_http_version : Versions.HTTP.t
         (** Use this as the highest HTTP version when sending requests *)
   ; https : HTTPS.t option
   ; h2c_upgrade : bool
@@ -65,7 +65,7 @@ type t =
   }
 
 let create
-    ?(max_http_version = Versions.ALPN.HTTP_1_1)
+    ?(max_http_version = Versions.HTTP.HTTP_1_1)
     ?https
     ?(h2c_upgrade = false)
     ?(tcp_nodelay = true)

--- a/lib/stubs/piaf_openssl_rand.c
+++ b/lib/stubs/piaf_openssl_rand.c
@@ -1,0 +1,60 @@
+/*----------------------------------------------------------------------------
+ * Copyright (c) 2022, António Nuno Monteiro
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *---------------------------------------------------------------------------*/
+
+#include <stdio.h>
+
+#include <caml/alloc.h>
+#include <caml/fail.h>
+#include <caml/memory.h>
+#include <caml/mlvalues.h>
+#include <caml/threads.h>
+
+#include <openssl/rand.h>
+
+CAMLprim value piaf_random_bytes(value size) {
+  int len = Int_val(size);
+  int ret = 0;
+  /* unsigned char *buf; */
+
+  value buf = caml_alloc_string(len);
+
+  caml_release_runtime_system();
+  /* buf = malloc(len * sizeof(char)); */
+  ret = RAND_bytes((unsigned char *)buf, len);
+  caml_acquire_runtime_system();
+
+  /* RAND_bytes() and RAND_priv_bytes() return 1 on success */
+  if (ret != 1) {
+    caml_failwith("piaf_random_bytes: failed generating random bytes");
+  }
+
+  return caml_copy_string((const char *)buf);
+}

--- a/lib/stubs/piaf_openssl_rand.c
+++ b/lib/stubs/piaf_openssl_rand.c
@@ -42,12 +42,10 @@
 CAMLprim value piaf_random_bytes(value size) {
   int len = Int_val(size);
   int ret = 0;
-  /* unsigned char *buf; */
 
   value buf = caml_alloc_string(len);
 
   caml_release_runtime_system();
-  /* buf = malloc(len * sizeof(char)); */
   ret = RAND_bytes((unsigned char *)buf, len);
   caml_acquire_runtime_system();
 

--- a/lib/versions.ml
+++ b/lib/versions.ml
@@ -39,12 +39,42 @@ let rec drop_while f xs =
   match xs with [] -> [] | y :: ys -> if f y then drop_while f ys else xs
 
 module HTTP = struct
-  include Httpaf.Version
+  type t =
+    | HTTP_1_0
+    | HTTP_1_1
+    | HTTP_2
 
-  let v1_0 = { major = 1; minor = 0 }
-  let v1_1 = { major = 1; minor = 1 }
-  let v2_0 = { major = 2; minor = 0 }
-  let equal v1 v2 = compare v1 v2 = 0
+  let to_string = function
+    | HTTP_1_0 -> "HTTP/1.0"
+    | HTTP_1_1 -> "HTTP/1.1"
+    | HTTP_2 -> "HTTP/2.0"
+
+  let pp fmt version = Format.fprintf fmt "%s" (to_string version)
+
+  module Raw = struct
+    include Httpaf.Version
+
+    let v1_0 = { major = 1; minor = 0 }
+    let v1_1 = { major = 1; minor = 1 }
+    let v2_0 = { major = 2; minor = 0 }
+    let equal v1 v2 = compare v1 v2 = 0
+
+    let to_version = function
+      | { major = 1; minor = 0 } -> Some HTTP_1_0
+      | { major = 1; minor = 1 } -> Some HTTP_1_1
+      | { major = 2; minor = 0 } -> Some HTTP_2
+      | _ -> None
+
+    let to_version_exn version =
+      match to_version version with
+      | Some x -> x
+      | None -> raise (Failure "Versions.ALPN.of_version_exn")
+
+    let of_version = function
+      | HTTP_1_0 -> v1_0
+      | HTTP_1_1 -> v1_1
+      | HTTP_2 -> v2_0
+  end
 end
 
 module TLS = struct
@@ -93,50 +123,30 @@ module TLS = struct
 end
 
 module ALPN = struct
-  type t =
-    | HTTP_1_0
-    | HTTP_1_1
-    | HTTP_2
-
-  let of_version = function
-    | { HTTP.major = 1; minor = 0 } -> Some HTTP_1_0
-    | { major = 1; minor = 1 } -> Some HTTP_1_1
-    | { major = 2; minor = 0 } -> Some HTTP_2
-    | _ -> None
-
-  let of_version_exn version =
-    match of_version version with
-    | Some x -> x
-    | None -> raise (Failure "Versions.ALPN.of_version_exn")
-
-  let to_version = function
-    | HTTP_1_0 -> HTTP.v1_0
-    | HTTP_1_1 -> HTTP.v1_1
-    | HTTP_2 -> HTTP.v2_0
-
   let of_string = function
-    | "http/1.0" -> Some HTTP_1_0
+    | "http/1.0" -> Some HTTP.HTTP_1_0
     | "http/1.1" -> Some HTTP_1_1
     | "h2" -> Some HTTP_2
     | _ -> None
 
   (* https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids *)
   let to_string = function
-    | HTTP_1_0 -> "http/1.0"
+    | HTTP.HTTP_1_0 -> "http/1.0"
     | HTTP_1_1 -> "http/1.1"
     | HTTP_2 -> "h2"
 
-  let versions_desc = HTTP.[ v2_0; v1_1; v1_0 ]
+  let versions_desc = HTTP.Raw.[ v2_0; v1_1; v1_0 ]
 
-  let protocols_of_version (max_version : t) =
+  let protocols_of_version (max_version : HTTP.t) =
     let wanted =
       drop_while
-        (fun version -> HTTP.compare version (to_version max_version) > 0)
+        (fun version ->
+          HTTP.Raw.compare version (HTTP.Raw.of_version max_version) > 0)
         versions_desc
     in
     List.map
       (fun v ->
-        let alpn = of_version_exn v in
+        let alpn = HTTP.Raw.to_version_exn v in
         to_string alpn)
       wanted
 end

--- a/lib/ws.ml
+++ b/lib/ws.ml
@@ -1,0 +1,117 @@
+(*----------------------------------------------------------------------------
+ * Copyright (c) 2022, António Nuno Monteiro
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *---------------------------------------------------------------------------*)
+
+open Eio.Std
+module Wsd = Websocketaf.Wsd
+module Websocket = Websocketaf.Websocket
+
+let src = Logs.Src.create "piaf.ws" ~doc:"Piaf Websocket module"
+
+module Log = (val Logs.src_log src : Logs.LOG)
+
+let upgrade_request ~headers ~scheme ~nonce target =
+  Request.of_http1
+    ~scheme
+    (Websocketaf.Handshake.create_request ~nonce ~headers target)
+
+module Descriptor : sig
+  type t
+  type frame = Websocket.Opcode.t * string
+
+  val create : frames:frame Stream.t -> Wsd.t -> t
+  val frames : t -> frame Stream.t
+  val send_stream : t -> Bigstringaf.t IOVec.t Stream.t -> unit
+  val send_string_stream : t -> string Stream.t -> unit
+  val send_string : t -> string -> unit
+  val send_bigstring : t -> ?off:int -> ?len:int -> Bigstringaf.t -> unit
+  val send_ping : t -> unit
+  val send_pong : t -> unit
+  val flushed : t -> unit Promise.t
+  val close : t -> unit
+  val is_closed : t -> bool
+end = struct
+  type t =
+    { wsd : Wsd.t
+    ; frames : (Websocket.Opcode.t * string) Stream.t
+    }
+
+  type frame = Websocket.Opcode.t * string
+
+  let create ~frames wsd = { wsd; frames }
+  let frames t = t.frames
+
+  let send_bytes t ?(off = 0) ?len bytes =
+    let len = match len with Some l -> l | None -> Bytes.length bytes in
+    Wsd.send_bytes t.wsd ~kind:`Binary ~off ~len bytes
+
+  let send_iovec : t -> Bigstringaf.t IOVec.t -> unit =
+   fun t iovec ->
+    let { IOVec.buffer; off; len } = iovec in
+    Wsd.schedule t.wsd ~kind:`Binary ~off ~len buffer
+
+  let rec send_stream : t -> Bigstringaf.t IOVec.t Stream.t -> unit =
+   fun t stream ->
+    match Stream.take stream with
+    | Some iovec ->
+      send_iovec t iovec;
+      send_stream t stream
+    | None -> ()
+
+  let send_string t str = send_bytes t (Bytes.of_string str)
+
+  let rec send_string_stream : t -> string Stream.t -> unit =
+   fun t stream ->
+    match Stream.take stream with
+    | Some str ->
+      send_string t str;
+      send_string_stream t stream
+    | None -> ()
+
+  let send_bigstring : t -> ?off:int -> ?len:int -> Bigstringaf.t -> unit =
+   fun t ?(off = 0) ?len bstr ->
+    let len = match len with Some l -> l | None -> Bigstringaf.length bstr in
+    Wsd.schedule t.wsd ~kind:`Binary ~off ~len bstr
+
+  let send_ping t = Wsd.send_ping t.wsd
+  let send_pong t = Wsd.send_pong t.wsd
+
+  let flushed t =
+    let p, u = Promise.create () in
+    Wsd.flushed t.wsd (Promise.resolve u);
+    p
+
+  let close t = Wsd.close (* ~code:`Normal_closure *) t.wsd
+  let is_closed t = Wsd.is_closed t.wsd
+end
+
+module Handler = struct
+  type t = descriptor:Descriptor.t -> Bigstringaf.t IOVec.t Stream.t -> unit
+end

--- a/lib/ws.ml
+++ b/lib/ws.ml
@@ -137,6 +137,7 @@ module Handler = struct
 
     let eof () =
       Log.info (fun m -> m "Websocket connection EOF");
+      Websocketaf.Wsd.close wsd;
       push_to_frames None
     in
     { Websocketaf.Websocket_connection.frame; eof }

--- a/lib_test/helper_server.ml
+++ b/lib_test/helper_server.ml
@@ -194,7 +194,7 @@ module H2c = struct
       (ALPN.H2_handler.request_handler client_addr)
 
   let connection_handler =
-    let upgrade_handler client_addr (request : Request.t) upgrade =
+    let upgrade_handler client_addr (request : Request.t) ~sw:_ upgrade =
       let request =
         Httpaf.Request.create
           ~headers:
@@ -213,7 +213,7 @@ module H2c = struct
           of_list
             [ Well_known.connection, "Upgrade"; Well_known.upgrade, "h2c" ])
       in
-      Response.upgrade ~headers (upgrade_handler client_address request)
+      Response.Upgrade.generic ~headers (upgrade_handler client_address request)
 
   let listen ~sw ~network port =
     Server.Command.listen

--- a/lib_test/test_client.ml
+++ b/lib_test/test_client.ml
@@ -133,7 +133,7 @@ let test_https ~sw env () =
           follow_redirects = true
         ; max_redirects = 1
         ; allow_insecure = true
-        ; max_http_version = Versions.ALPN.HTTP_1_1
+        ; max_http_version = Versions.HTTP.HTTP_1_1
         }
       env
       (Uri.of_string "http://localhost:8080/alpn")
@@ -160,7 +160,7 @@ let test_https ~sw env () =
           follow_redirects = true
         ; max_redirects = 1
         ; allow_insecure = true
-        ; max_http_version = Versions.ALPN.HTTP_2
+        ; max_http_version = HTTP_2
         }
       env
       (Uri.of_string "http://localhost:8080/alpn")
@@ -169,7 +169,7 @@ let test_https ~sw env () =
   Alcotest.check
     response_testable
     "expected response"
-    (Response.create ~version:Versions.HTTP.v2_0 `OK)
+    (Response.create ~version:HTTP_2 `OK)
     response;
   let body = Body.to_string response.body in
   Alcotest.(check (result string error_testable))
@@ -207,7 +207,7 @@ let test_https_server_certs ~sw env () =
           follow_redirects = true
         ; max_redirects = 1
         ; allow_insecure = false
-        ; max_http_version = Versions.ALPN.HTTP_1_1
+        ; max_http_version = HTTP_1_1
         ; cacert = Some (Cert.Filepath (Helper_server.cert_path // "ca.pem"))
         }
       env
@@ -218,7 +218,7 @@ let test_https_server_certs ~sw env () =
     response_testable
     "expected response"
     (Response.create
-       ~version:Versions.HTTP.v1_1
+       ~version:HTTP_1_1
        ~headers:Headers.(of_list [ Well_known.content_length, "1" ])
        `OK)
     response;
@@ -237,7 +237,7 @@ let test_https_server_certs ~sw env () =
           follow_redirects = true
         ; max_redirects = 1
         ; allow_insecure = false
-        ; max_http_version = Versions.ALPN.HTTP_1_1
+        ; max_http_version = HTTP_1_1
         ; cacert = Some (Cert.Certpem certstring)
         }
       env
@@ -248,7 +248,7 @@ let test_https_server_certs ~sw env () =
     response_testable
     "expected response"
     (Response.create
-       ~version:Versions.HTTP.v1_1
+       ~version:HTTP_1_1
        ~headers:Headers.(of_list [ Well_known.content_length, "1" ])
        `OK)
     response;
@@ -278,7 +278,7 @@ let test_https_server_certs ~sw env () =
           follow_redirects = true
         ; max_redirects = 1
         ; allow_insecure = false
-        ; max_http_version = Versions.ALPN.HTTP_1_1
+        ; max_http_version = HTTP_1_1
         ; cacert = Some (Cert.Certpem certstring)
         }
       env
@@ -289,7 +289,7 @@ let test_https_server_certs ~sw env () =
     response_testable
     "expected response"
     (Response.create
-       ~version:Versions.HTTP.v1_1
+       ~version:HTTP_1_1
        ~headers:Headers.(of_list [ Well_known.content_length, "1" ])
        `OK)
     response;
@@ -313,7 +313,7 @@ let test_https_server_certs ~sw env () =
           follow_redirects = true
         ; max_redirects = 1
         ; allow_insecure = false
-        ; max_http_version = Versions.ALPN.HTTP_1_1
+        ; max_http_version = HTTP_1_1
         ; cacert = Some (Cert.Filepath (Helper_server.cert_path // "ca.pem"))
         }
       env
@@ -325,7 +325,7 @@ let test_https_server_certs ~sw env () =
     response_testable
     "expected response"
     (Response.create
-       ~version:Versions.HTTP.v1_1
+       ~version:HTTP_1_1
        ~headers:Headers.(of_list [ Well_known.content_length, "1" ])
        `OK)
     response;
@@ -353,7 +353,7 @@ let test_https_client_certs ~sw env () =
           follow_redirects = true
         ; max_redirects = 1
         ; allow_insecure = false
-        ; max_http_version = Versions.ALPN.HTTP_1_1
+        ; max_http_version = HTTP_1_1
         ; cacert = Some (Cert.Filepath (Helper_server.cert_path // "ca.pem"))
         ; clientcert = Some (Cert.Certpem clientcert, Cert.Certpem clientkey)
         }
@@ -365,7 +365,7 @@ let test_https_client_certs ~sw env () =
     response_testable
     "expected response"
     (Response.create
-       ~version:Versions.HTTP.v1_1
+       ~version:HTTP_1_1
        ~headers:Headers.(of_list [ Well_known.content_length, "1" ])
        `OK)
     response;
@@ -381,7 +381,7 @@ let test_https_client_certs ~sw env () =
           follow_redirects = true
         ; max_redirects = 1
         ; allow_insecure = false
-        ; max_http_version = Versions.ALPN.HTTP_1_1
+        ; max_http_version = HTTP_1_1
         ; cacert = Some (Cert.Filepath (Helper_server.cert_path // "ca.pem"))
         ; clientcert = Some (Cert.Filepath clientcert, Cert.Filepath clientkey)
         }
@@ -393,7 +393,7 @@ let test_https_client_certs ~sw env () =
     response_testable
     "expected response"
     (Response.create
-       ~version:Versions.HTTP.v1_1
+       ~version:HTTP_1_1
        ~headers:Headers.(of_list [ Well_known.content_length, "1" ])
        `OK)
     response;
@@ -409,7 +409,7 @@ let test_https_client_certs ~sw env () =
           follow_redirects = true
         ; max_redirects = 1
         ; allow_insecure = false
-        ; max_http_version = Versions.ALPN.HTTP_1_1
+        ; max_http_version = HTTP_1_1
         ; cacert = Some (Cert.Filepath (Helper_server.cert_path // "ca.pem"))
         }
       env
@@ -471,7 +471,7 @@ let test_h2c ~sw env () =
   Alcotest.check
     response_testable
     "expected response"
-    (Response.create ~version:Versions.HTTP.v2_0 `OK)
+    (Response.create ~version:HTTP_2 `OK)
     response;
   let body = Body.to_string response.body in
   Alcotest.(check (result string error_testable))
@@ -486,7 +486,7 @@ let test_h2c ~sw env () =
         { Config.default with
           h2c_upgrade = true
         ; (* But no HTTP/2 enabled *)
-          max_http_version = Versions.ALPN.HTTP_1_1
+          max_http_version = HTTP_1_1
         }
       env
       (Uri.of_string "http://localhost:9000/h2c")

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -93,6 +93,7 @@ in
         httpaf-eio
         gluten-eio
         h2-eio
+        websocketaf-eio
 
         multipart_form
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -93,7 +93,8 @@ in
         httpaf-eio
         gluten-eio
         h2-eio
-        websocketaf-eio
+        websocketaf
+        digestif
 
         multipart_form
 


### PR DESCRIPTION
TODOs:

- [ ] `ws://` / `wss://` support in `Piaf.Scheme`?
- [x] Better server support (using the `Piaf.Ws.Descriptor` API)
- [x] Fail if trying to upgrade over HTTP/2