### PR TITLE
add bind_to_address and backlog in server_config

### DIFF
--- a/examples/eio/eio_echo_post.ml
+++ b/examples/eio/eio_echo_post.ml
@@ -32,8 +32,10 @@ let main port =
         ~h2c_upgrade:true
         ~https:
           (HTTPS.create
-             ~cacert:(Filepath ca) (* ~allow_insecure:true *)
-             (* ~enforce_client_cert:true *)
+             ~cacert:(Filepath ca)
+               (* ~allow_insecure:true *)
+               (* ~enforce_client_cert:true *)
+             ~port
              (Filepath cert, Filepath priv_key))
         port)
   in

--- a/lib/piaf.mli
+++ b/lib/piaf.mli
@@ -785,6 +785,9 @@ module Server : sig
             (** Specifies whether to flush message headers to the transport
                 immediately, or if Piaf should wait for the first body bytes to
                 be written. Defaults to [false]. *)
+      ; backlog : int
+            (** The maximum length of the queue of pending connections. *)
+      ; address : Eio.Net.Ipaddr.v4v6  (** The address to listen on. *)
       }
 
     val create
@@ -796,6 +799,8 @@ module Server : sig
       -> ?buffer_size:int
       -> ?body_buffer_size:int
       -> ?flush_headers_immediately:bool
+      -> ?backlog:int
+      -> ?address:Eio.Net.Ipaddr.v4v6
       -> int
       -> t
   end
@@ -856,20 +861,15 @@ module Server : sig
     type server := t
     type t
 
-    val start
-      :  ?bind_to_address:Eio.Net.Ipaddr.v4v6
-      -> sw:Eio.Switch.t
-      -> Eio.Stdenv.t
-      -> server
-      -> t
-
+    val start : sw:Eio.Switch.t -> Eio.Stdenv.t -> server -> t
     val shutdown : t -> unit
 
     val listen
-      :  ?bind_to_address:Eio.Net.Ipaddr.v4v6
-      -> sw:Eio.Switch.t
+      :  sw:Eio.Switch.t
       -> network:Eio.Net.t
+      -> bind_to_address:Eio.Net.Ipaddr.v4v6
       -> port:int
+      -> backlog:int
       -> connection_handler
       -> t
     (** [listen ~sw ?bind_to_address ~network ~port connection_handler] starts a

--- a/lib/server.ml
+++ b/lib/server.ml
@@ -195,6 +195,7 @@ module Command = struct
       ~sw
       ~network
       ~port
+      ?(backlog = 128)
       connection_handler
     =
     let command_p, command_u = Promise.create () in
@@ -222,7 +223,7 @@ module Command = struct
                   Eio.Net.listen
                     ~reuse_addr:true
                     ~reuse_port:true
-                    ~backlog:10_000
+                    ~backlog
                     ~sw
                     network
                     address

--- a/lib/server.ml
+++ b/lib/server.ml
@@ -190,14 +190,7 @@ module Command = struct
 
   let shutdown t = t.resolver ()
 
-  let listen
-      ?(bind_to_address = Eio.Net.Ipaddr.V4.loopback)
-      ~sw
-      ~network
-      ~port
-      ?(backlog = 128)
-      connection_handler
-    =
+  let listen ~sw ~network ~bind_to_address ~port ~backlog connection_handler =
     let command_p, command_u = Promise.create () in
     let released_p, released_u = Promise.create () in
     Fiber.fork ~sw (fun () ->
@@ -244,14 +237,20 @@ module Command = struct
             Promise.resolve command_u command));
     Promise.await command_p
 
-  let start ?bind_to_address ~sw env server =
+  let start ~sw env server =
     let { config; _ } = server in
     let network = Eio.Stdenv.net env in
     let clock = Eio.Stdenv.clock env in
     (* TODO(anmonteiro): config option to listen only in HTTPS? *)
     let connection_handler = http_connection_handler server in
     let ({ resolver = http_resolver; _ } as command) =
-      listen ?bind_to_address ~sw ~network ~port:config.port connection_handler
+      listen
+        ~bind_to_address:config.address
+        ~sw
+        ~network
+        ~port:config.port
+        ~backlog:config.backlog
+        connection_handler
     in
     match config.https with
     | None -> command
@@ -263,7 +262,13 @@ module Command = struct
           { server with config = { server.config with https = Some https } }
       in
       let { resolver = https_resolver; _ } =
-        listen ?bind_to_address ~sw ~network ~port:https.port connection_handler
+        listen
+          ~bind_to_address:config.address
+          ~sw
+          ~network
+          ~port:https.port
+          ~backlog:config.backlog
+          connection_handler
       in
       { command with
         resolver =

--- a/lib/server_config.ml
+++ b/lib/server_config.ml
@@ -62,6 +62,9 @@ type t =
         (** Specifies whether to flush message headers to the transport
             immediately, or if Piaf should wait for the first body bytes to be
             written. Defaults to [false]. *)
+  ; backlog : int
+        (** The maximum length of the queue of pending connections. *)
+  ; address : Eio.Net.Ipaddr.v4v6  (** The address to listen on. *)
   }
 
 let create
@@ -73,6 +76,8 @@ let create
     ?(buffer_size = 0x4000)
     ?(body_buffer_size = 0x1000)
     ?(flush_headers_immediately = false)
+    ?(backlog = 128)
+    ?(address = Eio.Net.Ipaddr.V4.loopback)
     port
   =
   { port
@@ -86,6 +91,8 @@ let create
   ; (* TODO: we don't really support push yet. *)
     enable_http2_server_push = false
   ; flush_headers_immediately
+  ; backlog
+  ; address
   }
 
 let to_http1_config { body_buffer_size; buffer_size; _ } =

--- a/lib_test/helper_server.mli
+++ b/lib_test/helper_server.mli
@@ -8,6 +8,8 @@ val listen
   -> ?check_client_cert:bool
   -> ?certfile:string
   -> ?certkey:string
+  -> ?bind_to_address:Eio.Net.Ipaddr.v4v6
+  -> ?backlog:int
   -> sw:Eio.Switch.t
   -> network:Eio.Net.t
   -> unit
@@ -18,6 +20,13 @@ val teardown : t -> unit
 module H2c : sig
   type t
 
-  val listen : sw:Eio.Switch.t -> network:Eio.Net.t -> int -> t
+  val listen
+    :  sw:Eio.Switch.t
+    -> network:Eio.Net.t
+    -> bind_to_address:Eio.Net.Ipaddr.v4v6
+    -> port:int
+    -> backlog:int
+    -> t
+
   val teardown : t -> unit
 end

--- a/lib_test/test_client.ml
+++ b/lib_test/test_client.ml
@@ -436,7 +436,14 @@ let test_https_client_certs ~sw env () =
 
 let test_h2c ~sw env () =
   let network = Eio.Stdenv.net env in
-  let server = Helper_server.H2c.listen ~sw ~network 9000 in
+  let server =
+    Helper_server.H2c.listen
+      ~sw
+      ~network
+      ~bind_to_address:Eio.Net.Ipaddr.V4.loopback
+      ~port:9000
+      ~backlog:128
+  in
   (* Not configured to follow the h2c upgrade *)
   let response =
     Client.Oneshot.get


### PR DESCRIPTION
Make server backlog an optional argument and change the default from 10000 to 128.

## Alternatives

Wait for this EIO PR https://github.com/ocaml-multicore/eio/pull/316 or add somaxconn syscall to get the max connection.

## Why 128? 
It seems the default max connection of Ubuntu: https://stackoverflow.com/a/36597268/8778072
Others libraries uses https://github.com/mirage/ocaml-cohttp/blob/11aa9e41466a1e0c9f06ecc1fab66bacff0b4201/cohttp-eio/src/server.ml#L144
