### PR TITLE
Update connection error handling for breaking Eio changes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -38,11 +38,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1670368740,
-        "narHash": "sha256-oCKKpHN4akFIsQexgm2FdGl/r+bBDzIDuifUcHR0jLc=",
+        "lastModified": 1673369367,
+        "narHash": "sha256-w+NQkhcUvwVhMB0Q9psIzXzNHCufVPsrbX+rlKCDLmU=",
         "owner": "nix-ocaml",
         "repo": "nix-overlays",
-        "rev": "aa882d91c8356bfc2351388649b0bfd480f0602e",
+        "rev": "6b5187a3e3b91a81b4b1f3a9165be3c8a27b900d",
         "type": "github"
       },
       "original": {
@@ -53,17 +53,17 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1670242877,
-        "narHash": "sha256-jBLh7dRHnbfvPPA9znOC6oQfKrCPJ0El8Zoe0BqnCjQ=",
+        "lastModified": 1673179929,
+        "narHash": "sha256-mkDqQat24NMqf4z5rK6M4Y+68qVauCSDYouqD3hl66c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6e51c97f1c849efdfd4f3b78a4870e6aa2da4198",
+        "rev": "c109fe7e80390ebe9b55913646ecb6f621c1ddd2",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6e51c97f1c849efdfd4f3b78a4870e6aa2da4198",
+        "rev": "c109fe7e80390ebe9b55913646ecb6f621c1ddd2",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages."${system}".extend (self: super: {
-          ocamlPackages = super.ocaml-ng.ocamlPackages_5_00;
+          ocamlPackages = super.ocaml-ng.ocamlPackages_5_0;
         });
       in
       rec {

--- a/lib/connection.ml
+++ b/lib/connection.ml
@@ -141,7 +141,8 @@ let connect ~sw ~clock ~network ~config conn_info =
   | Ok sock -> Ok sock
   | Error `Timeout
   | (exception
-      (Eio.Net.Connection_failure _ | Unix.Unix_error (ECONNREFUSED, _, _))) ->
+      ( Eio.Io (Eio.Net.E (Connection_failure _), _)
+      | Unix.Unix_error (ECONNREFUSED, _, _) )) ->
     Result.error
       (`Connect_error
         (Format.asprintf


### PR DESCRIPTION
Eio recently (Dec 1 2022) updated error handling for connections resulting in a breaking change. This change handles connection refused, timeouts, and connection reset errors with the same branch.

See https://github.com/ocaml-multicore/eio/commit/bef84ce78e8a7b9b3f4b58aaf0ec5917a3c6aaec