### PR TITLE
piaf.opam: eio and multipart_form are dependencies

### DIFF
--- a/piaf.opam
+++ b/piaf.opam
@@ -27,6 +27,8 @@ depends: [
   "rresult"
   "uri"
   "magic-mime"
+  "eio"
+  "multipart_form"
   "gluten-lwt-unix"
   "alcotest" {with-test}
   "alcotest-lwt" {with-test}


### PR DESCRIPTION
'opam pin add --dev piaf' fails without them.

Unfortunately this doesn't quite work yet because multipart_form usage fails to build:
```
#=== ERROR while compiling piaf.0.1.0 =========================================#
# context     2.1.2 | linux/x86_64 | ocaml-base-compiler.5.0.0 | pinned(git+https://github.com/anmonteiro/piaf.git#ffb6f09f)
# path        ~/.opam/5.0.0/.opam-switch/build/piaf.0.1.0
# command     ~/.opam/opam-init/hooks/sandbox.sh build dune build -p piaf -j 8
# exit-code   1
# env-file    ~/.opam/log/piaf-3002419-684c18.env
# output-file ~/.opam/log/piaf-3002419-684c18.out
### output ###
# [...]
# Error: This function has type
#          emitters:'a Multipart_form.emitters ->
#          Multipart_form.Content_type.t -> 'a Multipart_form.t Angstrom.t
#        It is applied to too many arguments; maybe you forgot a `;'.
# (cd _build/default && /home/edwin/.opam/5.0.0/bin/ocamlc.opt -w -40 -g -bin-annot -I multipart/.multipart.objs/byte -I /home/edwin/.opam/5.0.0/lib/angstrom -I /home/edwin/.opam/5.0.0/lib/base64 -I /home/edwin/.opam/5.0.0/lib/base64/rfc2045 -I /home/edwin/.opam/5.0.0/lib/bigarray-overlap -I /home/edwin/.opam/5.0.0/lib/bigstringaf -I /home/edwin/.opam/5.0.0/lib/bytes -I /home/edwin/.opam/5.0.0/[...]
# File "multipart/multipart.ml", line 280, characters 14-35:
# 280 |     AU.parse (Multipart_form.parser ~max_chunk_size ~emitters content_type)
#                     ^^^^^^^^^^^^^^^^^^^^^
# Error: This function has type
#          emitters:'a Multipart_form.emitters ->
#          Multipart_form.Content_type.t -> 'a Multipart_form.t Angstrom.t
#        It is applied to too many arguments; maybe you forgot a `;'.```