### PR TITLE
fix: don't send invalid HTTP/2 headers

### DIFF
--- a/lib/connection.ml
+++ b/lib/connection.ml
@@ -209,6 +209,7 @@ type t =
   | Conn :
       { impl : (module Http_intf.HTTPCommon with type Client.t = 'a)
       ; connection : 'a
+      ; config : Config.t
       ; fd : Eio_unix.Net.stream_socket_ty Eio.Net.stream_socket
       ; mutable info : Info.t
       ; mutable uri : Uri.t

--- a/lib/headers.ml
+++ b/lib/headers.ml
@@ -54,7 +54,7 @@ module Well_known = struct
   end
 end
 
-let add_length_related_headers ~body_length headers =
+let add_length_related_headers ~version ~body_length headers =
   (* TODO: check `Httpaf.Response.body_length` because we may have to issue a
    * 0-length response body. *)
   (* Don't step over an explicit `content-length` header. *)
@@ -62,10 +62,20 @@ let add_length_related_headers ~body_length headers =
   | `Fixed n ->
     add_unless_exists headers Well_known.content_length (Int64.to_string n)
   | `Chunked ->
-    add_unless_exists
-      headers
-      Well_known.transfer_encoding
-      Well_known.Values.chunked
+    (* From RFC9113§8.2.2:
+     *   An endpoint MUST NOT generate an HTTP/2 message containing
+     *   connection-specific header fields. This includes the Connection header
+     *   field and those listed as having connection-specific semantics in
+     *   Section 7.6.1 of [HTTP] (that is, Proxy-Connection, Keep-Alive,
+     *   Transfer-Encoding, and Upgrade).
+     *)
+    (match version with
+    | Versions.HTTP.HTTP_2 -> headers
+    | HTTP_1_0 | HTTP_1_1 ->
+      add_unless_exists
+        headers
+        Well_known.transfer_encoding
+        Well_known.Values.chunked)
   | `Close_delimited ->
     add_unless_exists headers Well_known.connection Well_known.Values.close
   | `Error _ | `Unknown -> headers
@@ -83,7 +93,7 @@ let canonicalize_headers ~body_length ~host ~version headers =
     | HTTP_1_0 | HTTP_1_1 ->
       add_unless_exists (of_list headers) Well_known.HTTP1.host host
   in
-  add_length_related_headers ~body_length headers
+  add_length_related_headers ~version ~body_length headers
 
 let host t ~version =
   match version with

--- a/lib/http1.ml
+++ b/lib/http1.ml
@@ -165,6 +165,13 @@ module MakeHTTP1 (Runtime_scheme : Scheme.Runtime.SCHEME) :
         (module HttpServer)
         ~fd
         ~scheme:Runtime_scheme.scheme
+        ~version:
+          (Option.value
+             ~default:HTTP_1_1
+             (Option.map
+                (fun (request : Httpaf.Request.t) ->
+                   Versions.HTTP.Raw.to_version_exn request.version)
+                request))
         ~error_handler
         ~start_response
         client_addr
@@ -194,7 +201,7 @@ module MakeHTTP1 (Runtime_scheme : Scheme.Runtime.SCHEME) :
         { Server_intf.Handler.ctx =
             { Request_info.client_address = client_addr
             ; scheme = Runtime_scheme.scheme
-            ; version = HTTP_1_1
+            ; version = Versions.HTTP.Raw.to_version_exn request.version
             ; sw
             }
         ; request = request_of_http1 ~body:request_body request

--- a/lib/http2.ml
+++ b/lib/http2.ml
@@ -171,6 +171,7 @@ end = struct
       ?request:(Option.map Request.of_h2 request)
       (module HttpServer)
       ~scheme:Runtime_scheme.scheme
+      ~version:HTTP_2
       ~fd
       ~error_handler
       ~start_response

--- a/lib/server_config.ml
+++ b/lib/server_config.ml
@@ -44,7 +44,10 @@ type t =
       - the highest HTTP version that ALPN will negotiate with the remote peer
       - the version to listen on the insecure server:
       - max_http_version == HTTP/2 && h2c_upgrade => HTTP/1.1 + H2c upgrade
-      - max_http_version == HTTP/2 => HTTP/2 server *)
+      - max_http_version == HTTP/2 => HTTP/2 server.
+
+      TODO(anmonteiro): doesn't make it possible to create a http/https server
+      where https is listening on http/2 and http on http1.1 *)
   ; https : HTTPS.t option
   ; h2c_upgrade : bool
   (** Send an upgrade to `h2c` (HTTP/2 over TCP) request to the server.


### PR DESCRIPTION
also:
- refactor: don't send redundant arguments