### PR TITLE
fix: broken link to `esy`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ in OCaml.
 
 Piaf is released to OPAM.
 
-You can depend on it via [esy](https://esy.sh/) or by running `opam install piaf`.
+You can depend on it by running `opam install piaf`.
 
 _Note_: make sure to mirror Piaf's own resolutions located in the [opam
 file](./piaf.opam).

--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ You can depend on it by running `opam install piaf`.
 _Note_: make sure to mirror Piaf's own resolutions located in the [opam
 file](./piaf.opam).
 
-[esy]: https://esy.sh
-
 # Usage & Examples
 
 TODO, read the [mli](./lib/piaf.mli) file for now.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ in OCaml.
 
 Piaf is released to OPAM.
 
-You can depend on it via [esy](esy) or by running `opam install piaf`.
+You can depend on it via [esy](https://esy.sh/) or by running `opam install piaf`.
 
 _Note_: make sure to mirror Piaf's own resolutions located in the [opam
 file](./piaf.opam).


### PR DESCRIPTION
Link to `esy` was broken.