### PR TITLE
Use dune-configurator to set C flags

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,12 +1,10 @@
-(lang dune 2.8)
+(lang dune 3.0)
 
 (using dune_site 0.1)
 
 (name piaf)
 
 (generate_opam_files true)
-
-(use_standard_c_and_cxx_flags true)
 
 (source
  (github anmonteiro/piaf))

--- a/dune-project
+++ b/dune-project
@@ -27,6 +27,7 @@
  (depends
   (ocaml
    (>= "5.1"))
+  dune-configurator
   logs
   (eio-ssl
    (>= 0.3.0))

--- a/dune-project
+++ b/dune-project
@@ -6,6 +6,8 @@
 
 (generate_opam_files true)
 
+(use_standard_c_and_cxx_flags true)
+
 (source
  (github anmonteiro/piaf))
 

--- a/lib/cflags/cflags.ml
+++ b/lib/cflags/cflags.ml
@@ -1,0 +1,29 @@
+module C = Configurator.V1
+
+let directory_exists fsp = Sys.file_exists fsp && Sys.is_directory fsp
+
+let default c : C.Pkg_config.package_conf =
+  if C.ocaml_config_var_exn c "system" = "macosx"
+  then
+    if directory_exists "/usr/local/opt/openssl"
+    then
+      { libs = [ "-L/usr/local/opt/openssl/lib" ]
+      ; cflags = [ "-I/usr/local/opt/openssl/include" ]
+      }
+    else { libs = [ "-L/opt/local/lib" ]; cflags = [ "-I/opt/local/include" ] }
+  else { libs = [ "-lssl"; "-lcrypto" ]; cflags = [] }
+
+let () =
+  C.main ~name:"ssl" (fun c ->
+      let default = default c in
+      let conf =
+        match C.Pkg_config.get c with
+        | None -> default
+        | Some pc ->
+          (match C.Pkg_config.query pc ~package:"openssl" with
+          | Some s -> s
+          | None -> default)
+      in
+      C.Flags.write_sexp "c_library_flags.sexp" conf.libs;
+      C.Flags.write_sexp "c_flags.sexp" conf.cflags)
+

--- a/lib/cflags/cflags.ml
+++ b/lib/cflags/cflags.ml
@@ -15,15 +15,14 @@ let default c : C.Pkg_config.package_conf =
 
 let () =
   C.main ~name:"ssl" (fun c ->
-      let default = default c in
-      let conf =
-        match C.Pkg_config.get c with
-        | None -> default
-        | Some pc ->
-          (match C.Pkg_config.query pc ~package:"openssl" with
-          | Some s -> s
-          | None -> default)
-      in
-      C.Flags.write_sexp "c_library_flags.sexp" conf.libs;
-      C.Flags.write_sexp "c_flags.sexp" conf.cflags)
-
+    let default = default c in
+    let conf =
+      match C.Pkg_config.get c with
+      | None -> default
+      | Some pc ->
+        (match C.Pkg_config.query pc ~package:"openssl" with
+        | Some s -> s
+        | None -> default)
+    in
+    C.Flags.write_sexp "c_library_flags.sexp" conf.libs;
+    C.Flags.write_sexp "c_flags.sexp" conf.cflags)

--- a/lib/cflags/dune
+++ b/lib/cflags/dune
@@ -1,0 +1,4 @@
+(executable
+ (name cflags)
+ (libraries dune-configurator))
+

--- a/lib/cflags/dune
+++ b/lib/cflags/dune
@@ -1,4 +1,3 @@
 (executable
  (name cflags)
  (libraries dune-configurator))
-

--- a/lib/dune
+++ b/lib/dune
@@ -21,4 +21,13 @@
   piaf.stream)
  (foreign_stubs
   (language c)
-  (names piaf_bigarray_read piaf_openssl_rand piaf_openssl_sha piaf_fdutils)))
+  (names piaf_bigarray_read piaf_openssl_rand piaf_openssl_sha piaf_fdutils)
+  (flags (:include c_flags.sexp)))
+ (c_library_flags
+  (:include c_library_flags.sexp)))
+
+(rule
+ (targets c_flags.sexp c_library_flags.sexp)
+ (action
+  (run ./cflags/cflags.exe)))
+

--- a/lib/dune
+++ b/lib/dune
@@ -22,7 +22,8 @@
  (foreign_stubs
   (language c)
   (names piaf_bigarray_read piaf_openssl_rand piaf_openssl_sha piaf_fdutils)
-  (flags (:include c_flags.sexp)))
+  (flags
+   (:include c_flags.sexp)))
  (c_library_flags
   (:include c_library_flags.sexp)))
 
@@ -30,4 +31,3 @@
  (targets c_flags.sexp c_library_flags.sexp)
  (action
   (run ./cflags/cflags.exe)))
-

--- a/nix/ci/test.nix
+++ b/nix/ci/test.nix
@@ -94,6 +94,7 @@ let
         dune
         findlib
         ocamlformat
+        dune-configurator
       ]);
       doCheck = true;
       checkPhase = ''

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -22,6 +22,8 @@ rec {
       ];
     };
 
+    buildInputs = with ocamlPackages; [ dune-configurator ];
+
     propagatedBuildInputs = with ocamlPackages; [
       logs
       eio-ssl

--- a/piaf.opam
+++ b/piaf.opam
@@ -9,7 +9,7 @@ license: "BSD-3-clause"
 homepage: "https://github.com/anmonteiro/piaf"
 bug-reports: "https://github.com/anmonteiro/piaf/issues"
 depends: [
-  "dune" {>= "2.8"}
+  "dune" {>= "3.0"}
   "ocaml" {>= "5.1"}
   "logs"
   "eio-ssl" {>= "0.3.0"}
@@ -38,9 +38,11 @@ build: [
     name
     "-j"
     jobs
+    "--promote-install-files=false"
     "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
+  ["dune" "install" "-p" name "--create-install-files" name]
 ]
 dev-repo: "git+https://github.com/anmonteiro/piaf.git"

--- a/piaf.opam
+++ b/piaf.opam
@@ -11,6 +11,7 @@ bug-reports: "https://github.com/anmonteiro/piaf/issues"
 depends: [
   "dune" {>= "3.0"}
   "ocaml" {>= "5.1"}
+  "dune-configurator"
   "logs"
   "eio-ssl" {>= "0.3.0"}
   "magic-mime"


### PR DESCRIPTION
The dune-configurator code is just copied over from the `ocaml-ssl` repo, with the component name changed from `config` to `cflags` because there's already a file `lib/config.ml`.

`(use_standard_c_and_cxx_flags true)` added as per a dune recommendation. This is the default in dune language version 3.0 onwards.

Fixes #213 