### PR TITLE
improve websocket support

### DIFF
--- a/lib/headers.ml
+++ b/lib/headers.ml
@@ -59,7 +59,7 @@ let add_length_related_headers ~version ~body_length headers =
    * 0-length response body. *)
   (* Don't step over an explicit `content-length` header. *)
   match body_length with
-  | `Fixed n ->
+  | `Fixed n when not (Int64.equal (Int64.of_string "0") n) ->
     add_unless_exists headers Well_known.content_length (Int64.to_string n)
   | `Chunked ->
     (* From RFC9113§8.2.2:
@@ -78,7 +78,7 @@ let add_length_related_headers ~version ~body_length headers =
         Well_known.Values.chunked)
   | `Close_delimited ->
     add_unless_exists headers Well_known.connection Well_known.Values.close
-  | `Error _ | `Unknown -> headers
+  | `Error _ | `Unknown | _ -> headers
 
 (* TODO: Add user-agent if not defined *)
 let canonicalize_headers ~body_length ~host ~version headers =

--- a/lib/scheme.ml
+++ b/lib/scheme.ml
@@ -39,8 +39,8 @@ type t =
 
 let of_uri uri =
   match Uri.scheme uri with
-  | None | Some "http" -> Ok `HTTP
-  | Some "https" -> Ok `HTTPS
+  | None | Some "http" | Some "ws" -> Ok `HTTP
+  | Some "https" | Some "wss" -> Ok `HTTPS
   (* We don't support anything else *)
   | Some other -> Error (`Msg (Format.asprintf "Unsupported scheme: %s" other))
 


### PR DESCRIPTION
Error out when websocket connection fails to upgrade (instead of silently returning a non-functioning socket). Also aliases the `ws://` and `wss://` schemes to `http://` and `https://`, respectively (which seems to work with the existing system).